### PR TITLE
#3 - Add column name to project assigning action

### DIFF
--- a/.github/workflows/assign_project.yml
+++ b/.github/workflows/assign_project.yml
@@ -16,3 +16,4 @@ jobs:
         if: github.event.action == 'opened'
         with:
           project: "https://github.com/orgs/beer-garden/projects/24"
+          column_name: "New Issues"


### PR DESCRIPTION
Closes #3 

Adds the column_name setting, which is required since the "To Do" column that the action defaults to does not exists on our Backlog project.