### PR TITLE
Issue/19

### DIFF
--- a/src/apps/command_view_app.tsx
+++ b/src/apps/command_view_app.tsx
@@ -78,10 +78,19 @@ class CommandViewApp extends Component<MyProps, MyState> {
     this.uischema = build.form;
     this.initialData = build.model;
     let requestData = null;
-    if (this.props.location.state) {
+    let pourItAgainRequest: any = window.localStorage.getItem(
+      `lastKnown_pour_it_again_request`
+    );
+    pourItAgainRequest = JSON.parse(pourItAgainRequest);
+    if (pourItAgainRequest) {
       requestData = this.formatRequestToData(
-        this.props.location.state.request,
+        pourItAgainRequest.request,
         this.initialData
+      );
+      console.log(pourItAgainRequest);
+      window.localStorage.setItem(
+        `lastKnown_pour_it_again_request`,
+        JSON.stringify(false)
       );
     }
     this.description = this.command["description"];

--- a/src/apps/command_view_app.tsx
+++ b/src/apps/command_view_app.tsx
@@ -10,7 +10,8 @@ import Breadcrumbs from "../components/breadcrumbs";
 import PageHeader from "../components/page_header";
 import CommandViewForm from "../components/command_view_form";
 import SystemsService from "../services/system_service";
-import { CommandParams, System } from "../custom_types/custom_types";
+import { CommandParams, Request, System } from "../custom_types/custom_types";
+import CacheService from "../services/cache_service";
 
 interface MyProps extends RouteComponentProps<CommandParams> {
   systems: System[];
@@ -78,19 +79,13 @@ class CommandViewApp extends Component<MyProps, MyState> {
     this.uischema = build.form;
     this.initialData = build.model;
     let requestData = null;
-    let pourItAgainRequest: any = window.localStorage.getItem(
-      `lastKnown_pour_it_again_request`
+    const pourItAgainRequest = CacheService.popQueue(
+      `lastKnownPourItAgainRequest`
     );
-    pourItAgainRequest = JSON.parse(pourItAgainRequest);
     if (pourItAgainRequest) {
       requestData = this.formatRequestToData(
-        pourItAgainRequest.request,
+        pourItAgainRequest,
         this.initialData
-      );
-      console.log(pourItAgainRequest);
-      window.localStorage.setItem(
-        `lastKnown_pour_it_again_request`,
-        JSON.stringify(false)
       );
     }
     this.description = this.command["description"];

--- a/src/apps/request_view_app.tsx
+++ b/src/apps/request_view_app.tsx
@@ -22,6 +22,7 @@ import RequestService from "../services/request_service";
 import { IdParam, Request, TableState } from "../custom_types/custom_types";
 import Breadcrumbs from "../components/breadcrumbs";
 import { AxiosResponse } from "axios";
+import CacheService from "../services/cache_service";
 
 interface MyProps extends RouteComponentProps<IdParam> {
   match: Match<IdParam>;
@@ -55,6 +56,12 @@ const RequestViewApp: FC<MyProps> = ({ match }: MyProps) => {
       ];
     }
     return tempData;
+  }
+
+  function pourItAgainClick() {
+    if (request) {
+      CacheService.pushQueue(request, `lastKnownPourItAgainRequest`);
+    }
   }
 
   function successCallback(response: AxiosResponse) {
@@ -205,21 +212,10 @@ const RequestViewApp: FC<MyProps> = ({ match }: MyProps) => {
           variant="contained"
           color="primary"
           onAuxClick={() => {
-            console.log("clicked");
-            window.localStorage.setItem(
-              `lastKnown_pour_it_again_request`,
-              JSON.stringify({
-                request: this.request,
-              })
-            );
+            pourItAgainClick();
           }}
           onClick={() => {
-            window.localStorage.setItem(
-              `lastKnown_pour_it_again_request`,
-              JSON.stringify({
-                request: this.request,
-              })
-            );
+            pourItAgainClick();
           }}
         >
           Pour it Again

--- a/src/apps/request_view_app.tsx
+++ b/src/apps/request_view_app.tsx
@@ -204,6 +204,23 @@ const RequestViewApp: FC<MyProps> = ({ match }: MyProps) => {
           }}
           variant="contained"
           color="primary"
+          onAuxClick={() => {
+            console.log("clicked");
+            window.localStorage.setItem(
+              `lastKnown_pour_it_again_request`,
+              JSON.stringify({
+                request: this.request,
+              })
+            );
+          }}
+          onClick={() => {
+            window.localStorage.setItem(
+              `lastKnown_pour_it_again_request`,
+              JSON.stringify({
+                request: this.request,
+              })
+            );
+          }}
         >
           Pour it Again
         </Button>


### PR DESCRIPTION
Closes #19 

Sets `request` in cache when using `pour it again` button so the `request` object accessible when user middle clicks button.

Test by middle clicking the `pour it again` button.