### PR TITLE
issue/30 reworked system admin page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import GardenViewApp from "./apps/garden_view_app";
 import JobCreateApp from "./apps/job_create_app";
 import CommandViewApp from "./apps/command_view_app";
 import SystemsService from "./services/system_service";
+import NamespacesService from "./services/namespace_service";
 import {
   CommandParams,
   GardenNameParam,
@@ -27,15 +28,21 @@ import {
 
 const App = (): JSX.Element => {
   const [systems, setSystems] = useState<System[]>([]);
+  const [namespaces, setNamespaces] = useState<string[]>([]);
 
   if (!systems[0]) {
     SystemsService.getSystems(successCallback);
+    NamespacesService.getNamespaces(successNamespaceCallback);
   }
 
   function successCallback(response: AxiosResponse) {
     setSystems(response.data);
   }
-  if (systems[0]) {
+
+  function successNamespaceCallback(response: AxiosResponse) {
+    setNamespaces(response.data);
+  }
+  if (systems[0] && namespaces[0]) {
     return (
       <Box>
         <Menu />
@@ -71,7 +78,12 @@ const App = (): JSX.Element => {
             />
             <Route
               path="/admin/systems"
-              component={() => <SystemsAdminApp systems={systems} />}
+              component={() => (
+                  <SystemsAdminApp
+                      namespaces={namespaces}
+                      systems={systems}
+                  />
+              )}
             />
             <Route
               path="/admin/gardens/:garden_name/"

--- a/src/apps/command_index_app.tsx
+++ b/src/apps/command_index_app.tsx
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
 import Button from "@material-ui/core/Button";
 import Box from "@material-ui/core/Box";
-
 import {
   Link as RouterLink,
   match as Match,

--- a/src/components/namespace_select.tsx
+++ b/src/components/namespace_select.tsx
@@ -1,0 +1,91 @@
+import React, { BaseSyntheticEvent, FC } from "react";
+import {
+  Checkbox,
+  Chip,
+  FormControl,
+  Input,
+  InputLabel,
+  Select,
+} from "@material-ui/core";
+import MenuItem from "@material-ui/core/MenuItem";
+import { makeStyles } from "@material-ui/core/styles";
+import CacheService from "../services/cache_service";
+
+interface NamespaceSelectProps {
+  namespaces: string[];
+  namespacesSelected: string[];
+  setNamespacesSelected(value: string[]): void;
+}
+
+const useStyles = makeStyles((theme) => ({
+  selectEmpty: {
+    marginTop: theme.spacing(2),
+  },
+  chips: {
+    display: "flex",
+    flexWrap: "wrap",
+  },
+  chip: {
+    margin: 2,
+  },
+  formControl: {
+    margin: theme.spacing(1),
+    minWidth: 255,
+  },
+}));
+
+const NamespaceSelect: FC<NamespaceSelectProps> = ({
+  namespaces,
+  namespacesSelected,
+  setNamespacesSelected,
+}: NamespaceSelectProps) => {
+  const classes = useStyles();
+  const handleChange = (event: BaseSyntheticEvent) => {
+    let selected: string[] = [];
+    if (event.target.value.includes("showAll")) {
+      if (namespaces.length !== namespacesSelected.length) {
+        selected = namespaces;
+      }
+    } else {
+      selected = event.target.value.sort();
+    }
+    CacheService.setItemInCache(
+      { namespacesSelected: selected },
+      `lastKnown_${window.location.href}`
+    );
+    setNamespacesSelected(selected);
+  };
+
+  return (
+    <FormControl size="small" className={classes.formControl}>
+      <InputLabel id="namespaceSelectLabel">Namespaces:</InputLabel>
+      <Select
+        labelId="namespaceSelectLabel"
+        value={namespacesSelected}
+        onChange={handleChange}
+        input={<Input />}
+        multiple
+        renderValue={(selected) => (
+          <div className={classes.chips}>
+            {(selected as string[]).map((value: string) => (
+              <Chip key={value} label={value} className={classes.chip} />
+            ))}
+          </div>
+        )}
+      >
+        <MenuItem value={"showAll"} key={"select all"}>
+          <Checkbox checked={namespaces.length === namespacesSelected.length} />
+          Select All
+        </MenuItem>
+        {namespaces.map((namespace: string) => (
+          <MenuItem value={namespace} key={namespace + "select"}>
+            <Checkbox checked={namespacesSelected.indexOf(namespace) > -1} />
+            {namespace}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+};
+
+export default NamespaceSelect;

--- a/src/services/cache_service.ts
+++ b/src/services/cache_service.ts
@@ -4,6 +4,7 @@ type CachedStates = {
   rowsPerPage?: number;
   request?: Request;
   requestQueue?: Request[];
+  namespacesSelected?: string[];
 };
 
 function getItem(key: string): CachedStates {
@@ -19,6 +20,16 @@ const CacheService = {
   getIndexLastState(key: string): { rowsPerPage: number } {
     const item = getItem(key);
     return { rowsPerPage: item.rowsPerPage || 5 };
+  },
+
+  getNamespacesSelected(
+    key: string,
+    defaultValue: string[] = []
+  ): { namespacesSelected: string[] } {
+    const item = getItem(key);
+    return {
+      namespacesSelected: item.namespacesSelected || defaultValue,
+    };
   },
 
   popQueue(key: string): Request | undefined | void {

--- a/src/services/namespace_service.ts
+++ b/src/services/namespace_service.ts
@@ -1,0 +1,14 @@
+import axios from "axios";
+import { SuccessCallback } from "../custom_types/custom_types";
+
+class NamespaceService {
+  getNamespaces(successCallback: SuccessCallback) {
+    axios
+      .get("/api/v1/namespaces?timestamp=" + new Date().getTime().toString())
+      .then((response) => successCallback(response));
+  }
+}
+
+const item = new NamespaceService();
+
+export default item;

--- a/src/services/system_service.ts
+++ b/src/services/system_service.ts
@@ -36,12 +36,17 @@ class SystemsService {
     });
   }
 
+  sortSystemsVersion(systems: System[]) {
+    systems.sort((a, b) => (a.version > b.version ? -1 : 1));
+    return systems;
+  }
+
   filterSystems(
     systems: System[],
     params: {
-      name: string | undefined;
-      namespace: string | undefined;
-      version: string | undefined;
+      name?: string | undefined;
+      namespace?: string | undefined;
+      version?: string | undefined;
     }
   ) {
     if (params.name) {


### PR DESCRIPTION
Closes #30

Redesigned the cards so they are more condensed to minimize white space caused from having multiple versions and instances, and separated systems by namespaces, with the ability to select which namespaces you want to see.

A system card now has a drop down to select version and the instances are a popup button with actions for the instance clicked.
The namespaces selected are cached so user does need to keep selecting the namespaces interest.