### PR TITLE
#57 - Fix effects for config and auth

### DIFF
--- a/src/components/Routes/Routes.tsx
+++ b/src/components/Routes/Routes.tsx
@@ -29,9 +29,9 @@ const Routes = () => {
 
       setAuthIsEnabled(data?.auth_enabled)
     }
-
-    fetchData()
-  }, [])
+ 
+    fetchData();
+  }, [getConfig])
 
   if (authIsEnabled === undefined) return null
 

--- a/src/containers/AuthContainer.tsx
+++ b/src/containers/AuthContainer.tsx
@@ -23,13 +23,13 @@ const useAuth = () => {
   const { axiosInstance } = useMyAxios()
   const navigate = useNavigate()
   const [user, _setUser] = useState<string | null>(null)
-  const onTokenRefreshRequired = useCallback(refresh, [])
+  const onTokenRefreshRequired = useCallback(refresh, [refresh])
 
   const setUser = (userName: string | null) => {
     _setUser(userName)
   }
 
-  const onTokenInvalid = () => setUser(null)
+  const onTokenInvalid = useCallback(() => { setUser(null) }, [])
 
   const { clearToken, setToken, isAuthenticated, getRefreshToken } = useToken(
     onTokenInvalid,

--- a/src/containers/ConfigContainer.tsx
+++ b/src/containers/ConfigContainer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { createContainer } from 'unstated-next'
 import { useMyAxios } from 'hooks/useMyAxios'
 
@@ -16,16 +16,16 @@ export interface ServerConfig {
 
 const useServerConfig = () => {
   const { axiosInstance } = useMyAxios()
-  const [config, _setConfig] = useState<ServerConfig | null>(null)
+  const [config, setConfig] = useState<ServerConfig | null>(null)
 
-  async function getConfig() {
-    console.log('Calling /config!')
+  const getConfig = useCallback(async () => {
     const { data } = await axiosInstance.get<ServerConfig>('/config', {
-      timeout: 1000,
-      headers: {
-        Accept: 'application/json',
-      },
-    })
+        timeout: 1000,
+        headers: {
+          Accept: 'application/json',
+        },
+      })
+
 
     console.log(
       'config AUTH_ENABLED: ',
@@ -35,15 +35,15 @@ const useServerConfig = () => {
       'config DEBUG_MODE: ',
       data.debug_mode ? 'yes' : String(data.debug_mode),
     )
-    _setConfig(data)
+    setConfig(data)
     return data
-  }
+  }, [setConfig, axiosInstance])
 
-  const authEnabled = useCallback(() => {
+  const authEnabled = useMemo(() => {
     return config?.auth_enabled ?? false
   }, [config])
 
-  const debugEnabled = useCallback(() => {
+  const debugEnabled = useMemo(() => {
     return config?.debug_mode ?? false
   }, [config])
 

--- a/src/hooks/useMyAxios.ts
+++ b/src/hooks/useMyAxios.ts
@@ -1,17 +1,13 @@
-import Axios, { AxiosInstance, AxiosRequestConfig } from 'axios'
+import Axios, { AxiosInstance } from 'axios'
 import { makeUseAxios } from 'axios-hooks'
-import { useCallback } from 'react'
-
-const BASE_URL = 'http://localhost:2337/' // TODO
-const BASIC_REQUEST_CONFIG: AxiosRequestConfig = {
-  baseURL: BASE_URL,
-}
+import { useCallback, useMemo } from 'react'
 
 const useMyAxios = () => {
   // const axiosInstance: AxiosInstance = Axios.create(BASIC_REQUEST_CONFIG)
-  const axiosInstance: AxiosInstance = Axios.create()
+  const axiosInstance: AxiosInstance = useMemo(() => { return Axios.create() }, [])
 
   const getUseAxios = useCallback(() => {
+    console.log("Making new axios!")
     return makeUseAxios({ axios: axiosInstance, cache: false })
   }, [axiosInstance])
 

--- a/src/hooks/useSystems.tsx
+++ b/src/hooks/useSystems.tsx
@@ -1,15 +1,13 @@
 import useAxios from 'axios-hooks'
 import { useEffect, useState } from 'react'
 import { System } from 'types/custom_types'
-import { ServerConfigContainer } from 'containers/ConfigContainer'
 
-const useSystems = <T,>(mapper: (system: System) => T) => {
+const useSystems = <T,>(mapper: (system: System) => T, authEnabled: boolean) => {
   const [systems, setSystems] = useState<T[]>([])
-  const { authEnabled } = ServerConfigContainer.useContainer()
   const [{ data, error }] = useAxios({
     url: '/api/v1/systems',
     method: 'GET',
-    withCredentials: authEnabled(),
+    withCredentials: authEnabled,
   })
 
   useEffect(() => {

--- a/src/hooks/useTokenExpiration.ts
+++ b/src/hooks/useTokenExpiration.ts
@@ -1,9 +1,9 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 export const useTokenExpiration = (
   onTokenRefreshRequired: () => Promise<void>
 ) => {
-  const clearAutomaticRefresh = useRef<number>()
+  const tokenRefreshTimerId = useRef<number>()
   const [tokenExpiration, setTokenExpiration] = useState<Date | undefined>(
     undefined
   )
@@ -13,20 +13,20 @@ export const useTokenExpiration = (
       const now = new Date()
       const triggerMillseconds = tokenExpiration.getTime() - now.getTime()
 
-      clearAutomaticRefresh.current = window.setTimeout(async () => {
+      tokenRefreshTimerId.current = window.setTimeout(async () => {
         onTokenRefreshRequired()
       }, triggerMillseconds)
     }
 
     return () => {
-      window.clearTimeout(clearAutomaticRefresh.current)
+      window.clearTimeout(tokenRefreshTimerId.current)
     }
   }, [onTokenRefreshRequired, tokenExpiration])
 
-  const clearAutomaticTokenRefresh = () => {
-    window.clearTimeout(clearAutomaticRefresh.current)
+  const clearAutomaticTokenRefresh = useCallback(() => {
+    window.clearTimeout(tokenRefreshTimerId.current)
     setTokenExpiration(undefined)
-  }
+  }, [setTokenExpiration])
 
   return {
     clearAutomaticTokenRefresh,

--- a/src/pages/CommandIndex/CommandIndexTable/data.tsx
+++ b/src/pages/CommandIndex/CommandIndexTable/data.tsx
@@ -126,7 +126,7 @@ const useCommands = () => {
   const [{ data, error }] = useAxios({
     url: '/api/v1/systems',
     method: 'get',
-    withCredentials: authEnabled(),
+    withCredentials: authEnabled,
   })
 
   useEffect(() => {

--- a/src/pages/CommandView/CommandView.tsx
+++ b/src/pages/CommandView/CommandView.tsx
@@ -23,7 +23,7 @@ const CommandView = () => {
   const [{ data, error }] = useAxios({
     url: '/api/v1/systems',
     method: 'get',
-    withCredentials: authEnabled(),
+    withCredentials: authEnabled,
   })
   useEffect(() => {
     if (data && !error) {

--- a/src/pages/GardenAdmin/GardenAdmin.tsx
+++ b/src/pages/GardenAdmin/GardenAdmin.tsx
@@ -13,7 +13,7 @@ const GardensAdmin = (): JSX.Element => {
   const [{ data, error }] = useAxios({
     url: '/api/v1/gardens',
     method: 'get',
-    withCredentials: authEnabled(),
+    withCredentials: authEnabled,
   })
 
   useEffect(() => {

--- a/src/pages/GardenAdminView/GardenAdminView.tsx
+++ b/src/pages/GardenAdminView/GardenAdminView.tsx
@@ -49,7 +49,7 @@ const GardenAdminView = () => {
   const [{ data, error }] = useAxios({
     url: '/api/v1/gardens/' + gardenName,
     method: 'get',
-    withCredentials: authEnabled(),
+    withCredentials: authEnabled,
   })
 
   useEffect(() => {

--- a/src/pages/JobIndex/JobIndex.tsx
+++ b/src/pages/JobIndex/JobIndex.tsx
@@ -12,7 +12,7 @@ const JobIndex = () => {
   const [{ data, error }] = useAxios({
     url: '/api/v1/jobs',
     method: 'get',
-    withCredentials: authEnabled(),
+    withCredentials: authEnabled,
   })
 
   useEffect(() => {

--- a/src/pages/RequestView/RequestView.tsx
+++ b/src/pages/RequestView/RequestView.tsx
@@ -52,7 +52,7 @@ const RequestView = () => {
   const [{ data, error }] = useAxios({
     url: '/api/v1/requests/' + id,
     method: 'get',
-    withCredentials: authEnabled(),
+    withCredentials: authEnabled,
   })
   useEffect(() => {
     if (data && !error) {

--- a/src/pages/RequestsIndex/RequestsIndexTable/data/data.tsx
+++ b/src/pages/RequestsIndex/RequestsIndexTable/data/data.tsx
@@ -32,15 +32,18 @@ const useRequests = () => {
   const { searchApi, config, updateUrl, updateConfig, updateApi } =
     useRequestsReducer()
 
+  const searchUrl = useMemo(() => {
+    return getUrlFromSearchApi(searchApi)
+  }, [searchApi])
+
   useEffect(() => {
-    const newUrl = getUrlFromSearchApi(searchApi)
-    updateUrl(newUrl)
+    updateUrl(searchUrl)
     updateConfig({
-      url: newUrl,
+      url: searchUrl,
       method: 'GET',
-      withCredentials: authEnabled(),
+      withCredentials: authEnabled,
     })
-  }, [updateUrl, updateConfig, authEnabled, searchApi])
+  }, [updateUrl, updateConfig, authEnabled, searchUrl])
 
   const axiosOptions: AxiosHooksOptions = {
     manual: true,
@@ -74,7 +77,7 @@ const useRequests = () => {
   const handleRefresh = useCallback(() => {
     execute(config, { useCache: false })
       .then((resp) =>
-        console.log('data.tsx - execute fired with response:', resp),
+        console.log('data.tsx - execute fired with response:', resp)
       )
       .catch((e) => console.log('data.tsx - error from execute:', e))
   }, [execute, config])

--- a/src/pages/SystemAdmin/SystemAdmin.tsx
+++ b/src/pages/SystemAdmin/SystemAdmin.tsx
@@ -61,7 +61,7 @@ const SystemAdmin = () => {
   const [namespaces, setNamespaces] = useState<string[]>([])
 
   const { systemsData, systemsError, namespaceData, namespaceError } =
-    useGetData(authEnabled())
+    useGetData(authEnabled)
 
   useEffect(() => {
     if (systemsData && !systemsError) {

--- a/src/pages/SystemIndex/SystemIndexTable/data.tsx
+++ b/src/pages/SystemIndex/SystemIndexTable/data.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react'
 import { Column } from 'react-table'
 import { System } from 'types/custom_types'
 import { ExploreButton } from '.'
+import { ServerConfigContainer } from 'containers/ConfigContainer'
 
 export type SystemIndexTableData = {
   namespace: string
@@ -27,7 +28,8 @@ const systemMapper = (system: System): SystemIndexTableData => {
 }
 
 const useSystemIndexTableData = () => {
-  return useSystems(systemMapper)
+  const { authEnabled } = ServerConfigContainer.useContainer()
+  return useSystems(systemMapper, authEnabled)
 }
 
 const useSystemIndexTableColumns = () => {


### PR DESCRIPTION
Closes #57 
- Switch `authEnabled` and `debugEnabled` in `ServerConfigContainer` to be memoized variables vs functions
- Add missing `getConfig` dependency to the config retrieval in Routes
- Fix the double fetch of the `Request` table's data - Add more useCallbacks and useMemo's for data that shouldn't be changing or doesn't need to be recomputed.
- Update `useToken::setToken()` to save the Request and Response handlers as callbacks, also remove the old interceptors when adding new ones

With appropriate useCallback and useMemo's, the current `axiosInstance`/`useAxios` pattern is sufficient.