### PR TITLE
Issue #54 v2: Updated dark and light themes

### DIFF
--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -15,7 +15,7 @@ const PageHeader = (
     <Box>
       <Box display="flex" alignItems="flex-end">
         <Box>
-          <Typography variant="h4">{title}</Typography>
+          <Typography variant="h4"><b>{title}</b></Typography>
         </Box>
         <Box pl={1}>
           <Typography>{description}</Typography>

--- a/src/components/Table/filters/DateRangeColumnFilter.tsx
+++ b/src/components/Table/filters/DateRangeColumnFilter.tsx
@@ -106,7 +106,7 @@ const DateRangeColumnFilter = ({
           ampm={false}
           OpenPickerButtonProps={{ id: `${id}_1_button` }}
         />
-        to
+         to 
         <DesktopDateTimePicker
           disableFuture
           onChange={(

--- a/src/components/Table/toolbar/ColumnHidePage.tsx
+++ b/src/components/Table/toolbar/ColumnHidePage.tsx
@@ -77,7 +77,7 @@ const ColumnHidePage = <T extends TableData>({
                   <Checkbox
                     value={`${column.id}`}
                     disabled={column.isVisible && onlyOneOptionLeft}
-                    color = 'secondary'
+                    color = "secondary"
                   />
                 }
                 label={column.render('Header')}

--- a/src/components/Table/toolbar/ColumnHidePage.tsx
+++ b/src/components/Table/toolbar/ColumnHidePage.tsx
@@ -77,6 +77,7 @@ const ColumnHidePage = <T extends TableData>({
                   <Checkbox
                     value={`${column.id}`}
                     disabled={column.isVisible && onlyOneOptionLeft}
+                    color = 'secondary'
                   />
                 }
                 label={column.render('Header')}

--- a/src/components/Table/toolbar/FilterPage.tsx
+++ b/src/components/Table/toolbar/FilterPage.tsx
@@ -66,7 +66,7 @@ const FilterPage = <T extends TableData>({
           </Typography>
           <form onSubmit={onSubmit}>
             <Button
-              color="primary"
+              color="secondary"
               onClick={resetFilters}
               sx={{ position: 'absolute', top: 18, right: 21 }}
             >
@@ -107,6 +107,7 @@ const FilterPage = <T extends TableData>({
                         display: 'inline-flex',
                         flexDirection: 'column',
                       }}
+
                     >
                       {column.render('Filter')}
                     </Box>

--- a/src/components/UI/Theme/Theme.ts
+++ b/src/components/UI/Theme/Theme.ts
@@ -9,30 +9,194 @@ const baseTheme = createTheme({
     fontWeightMedium: 700,
   },
 })
+//Colors for dark theme
+// Current: #61892F #86C232 #222629 #474B4F #6B6E70
+const dtext = '#FFFFFF';
+const dcolor1 = '#61892F';
+const dcolor2 = '#86C232';
+const dcolor3 = '#222629';
+const dcolor4 = '#474B4F';
+const dcolor5 = '#6B6E70';
 
 const darkTheme = createTheme({
   ...baseTheme,
   palette: {
-    mode: 'dark',
-    // primary: {
-    //   main: '#26a27b',
-    // },
-    // secondary: {
-    //   main: '#fafafa',
-    // },
+    background: {
+      default: dcolor4,
+    },
+    primary: {
+       main: dcolor3,
+     },
+     secondary: {
+       main: dcolor2,
+     },
+     text: {
+      primary: dtext,
+      secondary: dcolor1,
+    },
   },
+  components: {
+
+    MuiBreadcrumbs: {
+      styleOverrides: {
+        li: {
+          a: {
+            color: dcolor2
+          }
+        }
+      }
+    },
+
+    MuiButton: {
+      styleOverrides: {
+        sizeSmall: {
+          color: dcolor2
+        }
+      }
+    },
+
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          backgroundColor: dcolor5
+        }
+      }
+    },
+
+    MuiDrawer: {
+      styleOverrides: {
+        paper: {
+          backgroundColor: dcolor5,
+          color: dtext
+        }
+      }
+    },
+
+    MuiIconButton: {
+      styleOverrides: {
+        root: {
+          color: dcolor2
+        },
+      }
+    },
+
+    MuiListItemButton: {
+      styleOverrides: {
+        root: {
+          "&:hover": {
+            backgroundColor: dcolor4
+          }
+        }
+      }
+    },
+
+    MuiListItemIcon: {
+      styleOverrides: {
+        root: {
+          color: dtext
+        }
+      }
+    },
+
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          color: 'black'
+        }
+      }
+    },
+
+    MuiTableCell: {
+      styleOverrides: {
+        root: {
+          span: {
+            div: {
+              div: {
+                a: {
+                  color: dcolor2
+                }
+              },
+              a: {
+                color: dcolor2
+              }
+            }
+          }
+        }
+      }
+    },
+  }
 })
+
+// #3d5a80  #98c1d9  #e0fbfc  #ee6c4d #293241
+const lcolor1 = '#3d5a80';
+const lcolor2 = '#98c1d9';  
+const lcolor3 = '#e0fbfc';  
+const lcolor4 = '#ee6c4d'; 
+const lcolor5 = '#293241';
+
 const lightTheme = createTheme({
+  //theme suggestion:
+  // #3d5a80  #98c1d9  #e0fbfc  #ee6c4d #293241
+  //#ffffff // #00171f // #003459 // #007ea7 // #00a8e8
+  //#03045e // #0077b6 // #00b4d8 // #90e0ef // #caf0f8
   ...baseTheme,
   palette: {
-    mode: 'light',
-    // primary: {
-    //   main: '#fafafa',
-    // },
-    // secondary: {
-    //   main: '#26a27b',
-    // },
+    background: {
+      default: '#ffffff',
+    },
+    primary: {
+       main: lcolor1,
+     },
+     secondary: {
+       main: lcolor2,
+     },
+     text: {
+      primary: lcolor5,
+      secondary: lcolor4,
+    },
   },
+  components: {
+    MuiIconButton: {
+      styleOverrides: {
+        root: {
+          color: lcolor2
+        }
+      }
+    },
+    MuiDrawer: {
+      styleOverrides: {
+        paper: {
+          backgroundColor: lcolor3,
+          color: lcolor1
+        }
+      }
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          color: lcolor1
+        }
+      }
+    },
+    MuiTableCell: {
+      styleOverrides: {
+        root: {
+          span: {
+            div: {
+              div: {
+                a: {
+                  color: lcolor4
+                }
+              },
+              a: {
+                color: lcolor4
+              }
+            }
+          }
+        }
+      }
+    },
+  }
 })
 
 export { darkTheme, lightTheme }

--- a/src/components/UI/Theme/Theme.ts
+++ b/src/components/UI/Theme/Theme.ts
@@ -2,201 +2,127 @@ import { createTheme } from '@mui/material/styles'
 
 const baseTheme = createTheme({
   typography: {
-    fontFamily: '\'Roboto Condensed\', sans-serif',
-    fontSize: 14,
+    fontFamily: '\'Roboto Condensed\', sans-serif",
+    fontSize: 16,
     fontWeightLight: 300,
     fontWeightRegular: 400,
     fontWeightMedium: 700,
+    h4: {
+      fontSize: 32, //2x font size
+    },
   },
 })
-//Colors for dark theme
-// Current: #61892F #86C232 #222629 #474B4F #6B6E70
-const dtext = '#FFFFFF';
-const dcolor1 = '#61892F';
-const dcolor2 = '#86C232';
-const dcolor3 = '#222629';
-const dcolor4 = '#474B4F';
-const dcolor5 = '#6B6E70';
+
+//Main colors for dark theme
+const dtext = '#FFFFFF'
+const d1 = '#313B4D'
+const d2 = '#3B404A'
+const d3 = '#63abff'
+
+//one offs
+const d4 = '#2a2d34' //hover
+const d5 = '#7b7b7b' //disabled button
 
 const darkTheme = createTheme({
   ...baseTheme,
+  typography: {
+    body1: {
+      color: dtext,
+    },
+    button: {
+      color: dtext,
+    },
+  },
   palette: {
     background: {
-      default: dcolor4,
+      default: d1,
+      paper: d2,
     },
     primary: {
-       main: dcolor3,
-     },
-     secondary: {
-       main: dcolor2,
-     },
-     text: {
+      main: d2,
+    },
+    secondary: {
+      main: d3,
+    },
+    text: {
       primary: dtext,
-      secondary: dcolor1,
+      secondary: d3,
+    },
+    action: {
+      active: dtext,
+      hover: d4,
+      disabled: d5,
+      focus: dtext,
     },
   },
   components: {
-
-    MuiBreadcrumbs: {
+    MuiCssBaseline: {
       styleOverrides: {
-        li: {
-          a: {
-            color: dcolor2
-          }
-        }
-      }
-    },
-
-    MuiButton: {
-      styleOverrides: {
-        sizeSmall: {
-          color: dcolor2
-        }
-      }
-    },
-
-    MuiCard: {
-      styleOverrides: {
-        root: {
-          backgroundColor: dcolor5
-        }
-      }
-    },
-
-    MuiDrawer: {
-      styleOverrides: {
-        paper: {
-          backgroundColor: dcolor5,
-          color: dtext
-        }
-      }
-    },
-
-    MuiIconButton: {
-      styleOverrides: {
-        root: {
-          color: dcolor2
+        a: {
+          color: d3,
         },
-      }
+        span: {
+          fontSize: 16,
+        },
+      },
     },
 
-    MuiListItemButton: {
+    //Current hacky fix for filter text color
+    MuiFormLabel: {
       styleOverrides: {
         root: {
-          "&:hover": {
-            backgroundColor: dcolor4
-          }
-        }
-      }
+          '&.Mui-focused': {
+            color: dtext,
+          },
+        },
+      },
     },
-
-    MuiListItemIcon: {
-      styleOverrides: {
-        root: {
-          color: dtext
-        }
-      }
-    },
-
-    MuiPaper: {
-      styleOverrides: {
-        root: {
-          color: 'black'
-        }
-      }
-    },
-
-    MuiTableCell: {
-      styleOverrides: {
-        root: {
-          span: {
-            div: {
-              div: {
-                a: {
-                  color: dcolor2
-                }
-              },
-              a: {
-                color: dcolor2
-              }
-            }
-          }
-        }
-      }
-    },
-  }
+  },
 })
 
-// #3d5a80  #98c1d9  #e0fbfc  #ee6c4d #293241
-const lcolor1 = '#3d5a80';
-const lcolor2 = '#98c1d9';  
-const lcolor3 = '#e0fbfc';  
-const lcolor4 = '#ee6c4d'; 
-const lcolor5 = '#293241';
+//Main colors for light theme
+const l1 = '#ffffff'
+const l2 = '#003B6D'
+const l3 = '#0064ba'
+
+//one off for disabled link color
+const l4 = '#595959'
 
 const lightTheme = createTheme({
-  //theme suggestion:
-  // #3d5a80  #98c1d9  #e0fbfc  #ee6c4d #293241
-  //#ffffff // #00171f // #003459 // #007ea7 // #00a8e8
-  //#03045e // #0077b6 // #00b4d8 // #90e0ef // #caf0f8
   ...baseTheme,
   palette: {
+    mode: 'light',
     background: {
-      default: '#ffffff',
+      default: l1,
+      paper: l1,
     },
     primary: {
-       main: lcolor1,
-     },
-     secondary: {
-       main: lcolor2,
-     },
-     text: {
-      primary: lcolor5,
-      secondary: lcolor4,
+      main: l2,
+    },
+    secondary: {
+      main: l3,
+    },
+    text: {
+      secondary: l3,
+    },
+    action: {
+      active: l2,
+      disabled: l4,
+      focus: l2,
     },
   },
   components: {
-    MuiIconButton: {
+    MuiCssBaseline: {
       styleOverrides: {
-        root: {
-          color: lcolor2
-        }
-      }
+        a: {
+          color: l3,
+        },
+        span: {
+          fontSize: 16,
+        },
+      },
     },
-    MuiDrawer: {
-      styleOverrides: {
-        paper: {
-          backgroundColor: lcolor3,
-          color: lcolor1
-        }
-      }
-    },
-    MuiPaper: {
-      styleOverrides: {
-        root: {
-          color: lcolor1
-        }
-      }
-    },
-    MuiTableCell: {
-      styleOverrides: {
-        root: {
-          span: {
-            div: {
-              div: {
-                a: {
-                  color: lcolor4
-                }
-              },
-              a: {
-                color: lcolor4
-              }
-            }
-          }
-        }
-      }
-    },
-  }
+  },
 })
 
 export { darkTheme, lightTheme }

--- a/src/components/UI/Theme/Theme.ts
+++ b/src/components/UI/Theme/Theme.ts
@@ -2,7 +2,7 @@ import { createTheme } from '@mui/material/styles'
 
 const baseTheme = createTheme({
   typography: {
-    fontFamily: '\'Roboto Condensed\', sans-serif",
+    fontFamily: '\'Roboto Condensed\', sans-serif',
     fontSize: 16,
     fontWeightLight: 300,
     fontWeightRegular: 400,

--- a/src/pages/CommandIndex/CommandIndexTable/CommandIndexTable.tsx
+++ b/src/pages/CommandIndex/CommandIndexTable/CommandIndexTable.tsx
@@ -27,7 +27,7 @@ const CommandIndexTable = () => {
         <FormControlLabel
           label="Include hidden"
           control={
-            <Checkbox checked={includeHidden} onChange={hiddenOnChange} />
+            <Checkbox checked={includeHidden} onChange={hiddenOnChange} color='secondary'/>
           }
         />
       </Box>

--- a/src/pages/CommandIndex/CommandIndexTable/CommandIndexTable.tsx
+++ b/src/pages/CommandIndex/CommandIndexTable/CommandIndexTable.tsx
@@ -27,7 +27,7 @@ const CommandIndexTable = () => {
         <FormControlLabel
           label="Include hidden"
           control={
-            <Checkbox checked={includeHidden} onChange={hiddenOnChange} color='secondary'/>
+            <Checkbox checked={includeHidden} onChange={hiddenOnChange} color="secondary"/>
           }
         />
       </Box>

--- a/src/pages/RequestsIndex/RequestsIndexTable/RequestsIndexTable.tsx
+++ b/src/pages/RequestsIndex/RequestsIndexTable/RequestsIndexTable.tsx
@@ -18,6 +18,7 @@ import {
 } from 'react'
 import { Filters, SortingRule } from 'react-table'
 
+
 const RequestsIndexTable = () => {
   const {
     requestData: { isLoading, isErrored, requests },
@@ -100,6 +101,7 @@ const RequestsIndexTable = () => {
     }),
     [searchByOnChange, orderingOnChange, handleResultCount, handleStartPage],
   )
+  
 
   return (
     <SSRTable<
@@ -121,13 +123,17 @@ const RequestsIndexTable = () => {
           <Checkbox
             checked={includeChildren}
             onChange={includeChildrenOnChange}
+            color='secondary'
           />
         }
       />
       <FormControlLabel
         label="Show hidden"
         control={
-          <Checkbox checked={showHidden} onChange={showHiddenOnChange} />
+          <Checkbox 
+          checked={showHidden} 
+          onChange={showHiddenOnChange} 
+          color = 'secondary'/>
         }
       />
       {isErrored ? (
@@ -137,6 +143,7 @@ const RequestsIndexTable = () => {
       ) : (
         <LoadingButton
           size="small"
+          color = 'secondary'
           loadingIndicator="Loading..."
           loading={isLoading}
           startIcon={<RefreshIcon />}

--- a/src/pages/RequestsIndex/RequestsIndexTable/RequestsIndexTable.tsx
+++ b/src/pages/RequestsIndex/RequestsIndexTable/RequestsIndexTable.tsx
@@ -123,7 +123,7 @@ const RequestsIndexTable = () => {
           <Checkbox
             checked={includeChildren}
             onChange={includeChildrenOnChange}
-            color='secondary'
+            color="secondary"
           />
         }
       />
@@ -133,7 +133,7 @@ const RequestsIndexTable = () => {
           <Checkbox 
           checked={showHidden} 
           onChange={showHiddenOnChange} 
-          color = 'secondary'/>
+          color = "secondary"/>
         }
       />
       {isErrored ? (
@@ -143,7 +143,7 @@ const RequestsIndexTable = () => {
       ) : (
         <LoadingButton
           size="small"
-          color = 'secondary'
+          color = "secondary"
           loadingIndicator="Loading..."
           loading={isLoading}
           startIcon={<RefreshIcon />}

--- a/src/pages/SystemIndex/SystemIndexTable/ExploreButton.tsx
+++ b/src/pages/SystemIndex/SystemIndexTable/ExploreButton.tsx
@@ -16,7 +16,7 @@ const ExploreButton = (system: System) => {
       component={RouterLink}
       to={linkTo}
       variant="contained"
-      color="primary"
+      color="secondary"
     >
       Explore
     </Button>

--- a/src/pages/SystemIndex/SystemIndexTable/data.tsx
+++ b/src/pages/SystemIndex/SystemIndexTable/data.tsx
@@ -94,7 +94,7 @@ const useSystemIndexTableColumns = () => {
             disableGroupBy: true,
             disableFilters: true,
             canHide: false,
-            width: 120,
+            width: 300,
             midWidth: 90,
           },
         ],


### PR DESCRIPTION
Closes #54 

A second attempt at updating the dark and light themes. I have tried to make things less granular, the exceptions to this being in the table (which has its needed changes in CSS baseline) and one spot in a popup menu that may go away during other issues anyways. I changed various buttons and checkboxes in the rest of the code to use the theme palette component I thought was best, and also upped the text font sizes. There are still some things that don't look quite right because the UI will be changing more even after this issue eventually ends, but these are my suggestions for the main color schemes at least.

Feedback appreciated, especially on the light theme.