### PR TITLE
#98 - Removed pre-commit lint & pre-push test

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-prepush && npm test
+npx lint-prepush

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "husky": "^7.0.4",
     "jest": "^27.5.1",
     "lint-prepush": "^2.2.1",
-    "lint-staged": "^12.3.7",
     "prettier": "^2.7.1",
     "react-app-rewired": "^2.2.1"
   },
@@ -88,13 +87,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-push": "lint-prepush"
     }
-  },
-  "lint-staged": {
-    "*.{js,ts,tsx}": [
-      "eslint --fix"
-    ]
   },
   "proxy": "http://localhost:2337",
   "scripts": {


### PR DESCRIPTION
Fixes #98 and #97 

Removes unneeded dependencies, reconfigures behavior on pre-push to only lint, eliminates all git hook behavior on commit.