### PR TITLE
#99 - add table key, table name is optional

### DIFF
--- a/src/components/Table/SSRTable.tsx
+++ b/src/components/Table/SSRTable.tsx
@@ -84,7 +84,6 @@ interface TableProps<
   R extends string,
   S extends string,
 > extends TableOptions<T> {
-  tableName: string
   data: T[]
   columns: Column<T>[]
   fetchStatus: { isLoading: boolean; isErrored: boolean }
@@ -105,6 +104,8 @@ interface TableProps<
     handleResultCount: (resultCount: number) => void
     handleStartPage: (page: number) => void
   }
+  tableName?: string
+  tableKey?: string
 }
 
 const SSRTable = <
@@ -116,6 +117,7 @@ const SSRTable = <
 ): ReactElement => {
   const {
     tableName,
+    tableKey,
     data,
     columns,
     fetchStatus: { isLoading, isErrored },
@@ -136,7 +138,7 @@ const SSRTable = <
   } = props
 
   const [initialState, setInitialState] = useLocalStorage(
-    `tableState:${tableName}`,
+    `tableState:${tableKey || tableName}`,
     {} as Partial<TableState<T>>,
   )
 
@@ -261,11 +263,9 @@ const SSRTable = <
     <Typography>Error...</Typography>
   ) : (
     <>
-      <Toolbar name={tableName} instance={instance} />
+      <Toolbar name={tableName || ''} instance={instance} />
       <FilterChipBar<T> instance={instance} />
-
       <Box {...childProps}>{props.children}</Box>
-
       <StyledTable {...tableProps}>
         <TableHead>
           {headerGroups.map((headerGroup) => {
@@ -274,7 +274,6 @@ const SSRTable = <
               role: headerGroupRole,
               ...headerGroupProps
             } = headerGroup.getHeaderGroupProps()
-
             return (
               <TableHeadRow key={headerGroupKey} {...headerGroupProps}>
                 {headerGroup.headers.map((column) => {

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -80,12 +80,13 @@ const hooks = [
 ]
 
 interface TableProps<T extends ObjectWithStringKeys> extends TableOptions<T> {
-  tableName: string
   data: T[]
   columns: Column<T>[]
   setSelection?: Dispatch<SetStateAction<T[]>>
   showGlobalFilter?: boolean
   maxrows?: number
+  tableName?: string
+  tableKey?: string
 }
 
 const DEBUG_INITIAL_STATE = false
@@ -95,6 +96,7 @@ const Table = <T extends ObjectWithStringKeys>(
 ): ReactElement => {
   const {
     tableName,
+    tableKey,
     data,
     columns,
     showGlobalFilter,
@@ -103,7 +105,7 @@ const Table = <T extends ObjectWithStringKeys>(
   } = props
 
   const [initialState, _setInitialState] = useLocalStorage(
-    `tableState:${tableName}`,
+    `tableState:${tableKey || tableName}`,
     {} as Partial<TableState<T>>,
   )
 
@@ -188,9 +190,8 @@ const Table = <T extends ObjectWithStringKeys>(
 
   return (
     <>
-      <Toolbar name={tableName} instance={instance} />
+      <Toolbar name={tableName || ''} instance={instance} />
       <FilterChipBar<T> instance={instance} />
-
       <Box {...childProps}>
         <Stack direction="row" spacing={3}>
           {showGlobalFilter ? (
@@ -203,7 +204,6 @@ const Table = <T extends ObjectWithStringKeys>(
           {props.children}
         </Stack>
       </Box>
-
       <StyledTable {...tableProps}>
         <TableHead>
           {headerGroups.map((headerGroup) => {
@@ -212,7 +212,6 @@ const Table = <T extends ObjectWithStringKeys>(
               role: headerGroupRole,
               ...headerGroupProps
             } = headerGroup.getHeaderGroupProps()
-
             return (
               <TableHeadRow key={headerGroupKey} {...headerGroupProps}>
                 {headerGroup.headers.map((column) => {

--- a/src/components/UI/NavigationBar/DrawerFooter.test.tsx
+++ b/src/components/UI/NavigationBar/DrawerFooter.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { ServerConfigContainer } from 'containers/ConfigContainer'
 import { BrowserRouter } from 'react-router-dom'
-import { serverConfig, versionConfig } from 'test/testData'
+import { TServerConfig, TVersionConfig } from 'test/testData'
 
 import { DrawerFooter } from './DrawerFooter'
 
@@ -16,7 +16,7 @@ describe('DrawerFooter', () => {
     )
     await waitFor(() => {
       expect(container).toContainHTML(
-        `Beer Garden <b>${versionConfig.beer_garden_version}</b>`,
+        `Beer Garden <b>${TVersionConfig.beer_garden_version}</b>`,
       )
     })
   })
@@ -33,7 +33,7 @@ describe('DrawerFooter', () => {
     await waitFor(() => {
       expect(screen.getByTestId('apiLink')).toHaveAttribute(
         'href',
-        `${serverConfig.url_prefix}swagger/index.html?config=${serverConfig.url_prefix}config/swagger`,
+        `${TServerConfig.url_prefix}swagger/index.html?config=${TServerConfig.url_prefix}config/swagger`,
       )
     })
   })

--- a/src/hooks/useBlockList.tsx
+++ b/src/hooks/useBlockList.tsx
@@ -12,7 +12,7 @@ export const useBlockList = () => {
 
   const getList = () => {
     axiosInstance
-      .get<BlockedList>('/api/v1/commandpublishingblocklist/')
+      .get<BlockedList>('/api/v1/commandpublishingblocklist')
       .then((resolved) => {
         if (resolved) setList(resolved.data.command_publishing_blocklist)
       })
@@ -45,7 +45,7 @@ export const useBlockList = () => {
   const addBlockList = (command: CommandIndexTableData[]) => {
     axiosInstance
       .post<BlockedList>(
-        '/api/v1/commandpublishingblocklist/',
+        '/api/v1/commandpublishingblocklist',
         {
           command_publishing_blocklist: command,
         },

--- a/src/pages/CommandBlocklistView/CommandBlocklistView.test.tsx
+++ b/src/pages/CommandBlocklistView/CommandBlocklistView.test.tsx
@@ -1,0 +1,87 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { ServerConfigContainer } from 'containers/ConfigContainer'
+import { BrowserRouter } from 'react-router-dom'
+import { TBlockedCommand, TCommand } from 'test/testData'
+
+import { CommandBlocklistView } from './CommandBlocklistView'
+
+describe('CommandBlocklistView', () => {
+  test('render table of blocked commands', async () => {
+    render(
+      <BrowserRouter>
+        <ServerConfigContainer.Provider>
+          <CommandBlocklistView />
+        </ServerConfigContainer.Provider>
+      </BrowserRouter>,
+    )
+    expect(screen.getByText('Command Publishing Blocklist')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText(TBlockedCommand.command)).toBeInTheDocument()
+    })
+  })
+
+  test('render button to add command', () => {
+    render(
+      <BrowserRouter>
+        <ServerConfigContainer.Provider>
+          <CommandBlocklistView />
+        </ServerConfigContainer.Provider>
+      </BrowserRouter>,
+    )
+    expect(
+      screen.getByRole('button', { name: 'Add command' }),
+    ).toBeInTheDocument()
+  })
+
+  test('add modal submits', async () => {
+    render(
+      <BrowserRouter>
+        <ServerConfigContainer.Provider>
+          <CommandBlocklistView />
+        </ServerConfigContainer.Provider>
+      </BrowserRouter>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Add command' }))
+    await waitFor(() => {
+      expect(screen.getByText('Submit')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Submit'))
+    await waitFor(() => {
+      expect(screen.queryByText('Submit')).not.toBeInTheDocument()
+    })
+  })
+
+  test('add modal cancels', async () => {
+    render(
+      <BrowserRouter>
+        <ServerConfigContainer.Provider>
+          <CommandBlocklistView />
+        </ServerConfigContainer.Provider>
+      </BrowserRouter>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Add command' }))
+    await waitFor(() => {
+      expect(screen.getByText('Cancel')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(screen.queryByText('Cancel')).not.toBeInTheDocument()
+  })
+
+  test('adds command to blocklist', async () => {
+    render(
+      <BrowserRouter>
+        <ServerConfigContainer.Provider>
+          <CommandBlocklistView />
+        </ServerConfigContainer.Provider>
+      </BrowserRouter>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Add command' }))
+    fireEvent.click(
+      screen.getByRole('checkbox', { name: 'Toggle Row Selected' }),
+    )
+    fireEvent.click(screen.getByText('Submit'))
+    await waitFor(() => {
+      expect(screen.getByText(TCommand.name)).toBeInTheDocument()
+    })
+  })
+})

--- a/src/pages/CommandBlocklistView/CommandBlocklistView.test.tsx
+++ b/src/pages/CommandBlocklistView/CommandBlocklistView.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { ServerConfigContainer } from 'containers/ConfigContainer'
 import { BrowserRouter } from 'react-router-dom'
 import { TBlockedCommand, TCommand } from 'test/testData'

--- a/src/pages/CommandBlocklistView/CommandBlocklistView.tsx
+++ b/src/pages/CommandBlocklistView/CommandBlocklistView.tsx
@@ -101,7 +101,7 @@ export const CommandBlocklistView = () => {
         }}
         content={
           <Table
-            tableName="All Commands"
+            tableKey="BlocklistAdd"
             data={commandListData}
             columns={useModalColumns()}
             maxrows={10}
@@ -112,7 +112,7 @@ export const CommandBlocklistView = () => {
       <PageHeader title="Command Publishing Blocklist" description="" />
       <Divider />
       <Table
-        tableName="Blocked Commands"
+        tableKey="Blocklist"
         data={blocklistData}
         columns={useTableColumns()}
       />

--- a/src/pages/JobView/JobButton.test.tsx
+++ b/src/pages/JobView/JobButton.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { BrowserRouter } from 'react-router-dom'
-import { job as mockJob } from 'test/testData'
+import { TJob } from 'test/testData'
 import { Job } from 'types/backend-types'
 
 import { JobButton } from './JobButton'
@@ -18,7 +18,7 @@ describe('JobButton', () => {
   afterAll(() => jest.unmock('services/job.service/job.service'))
 
   beforeEach(() => {
-    jData = Object.assign({}, mockJob)
+    jData = Object.assign({}, TJob)
   })
 
   test('pause job on click', async () => {

--- a/src/pages/JobView/JobView.test.tsx
+++ b/src/pages/JobView/JobView.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import Router from 'react-router-dom'
 import { BrowserRouter } from 'react-router-dom'
-import { job as mockJob } from 'test/testData'
+import { TJob } from 'test/testData'
 import { Job } from 'types/backend-types'
 
 import { JobView } from './JobView'
@@ -28,7 +28,7 @@ describe('JobView', () => {
   })
 
   beforeAll(() => {
-    mockJobResponse = { data: Object.assign({}, mockJob) }
+    mockJobResponse = { data: Object.assign({}, TJob) }
   })
 
   test('renders Delete button', () => {

--- a/src/test/testAxiosMock.ts
+++ b/src/test/testAxiosMock.ts
@@ -7,9 +7,11 @@ axios.defaults.baseURL = 'http://localhost:4000'
 
 const mock = new MockAdapter(axios)
 
-mock.onGet('/config').reply(200, mockData.serverConfig)
-mock.onGet('/version').reply(200, mockData.versionConfig)
-mock.onGet('/api/v1/jobs').reply(200, mockData.job)
+mock.onGet('/config').reply(200, mockData.TServerConfig)
+mock.onGet('/version').reply(200, mockData.TVersionConfig)
+mock.onGet('/api/v1/jobs').reply(200, mockData.TJob)
+mock.onGet('/api/v1/commandpublishingblocklist').reply(200, mockData.TBlocklist)
+mock.onGet('/api/v1/systems').reply(200, [mockData.TSystem])
 
 mock.onPost('/api/v1/requests').reply(200, { id: 'testRequest' })
 

--- a/src/test/testData.ts
+++ b/src/test/testData.ts
@@ -1,6 +1,16 @@
-import { DateTrigger, Job, RequestTemplate } from 'types/backend-types'
+import {
+  BlockedCommand,
+  BlockedList,
+  Command,
+  DateTrigger,
+  Instance,
+  Job,
+  Parameter,
+  RequestTemplate,
+  System,
+} from 'types/backend-types'
 
-export const serverConfig = {
+export const TServerConfig = {
   application_name: 'testApp',
   auth_enabled: false,
   trusted_header_auth_enabled: false,
@@ -12,13 +22,13 @@ export const serverConfig = {
   url_prefix: '/',
 }
 
-export const versionConfig = {
+export const TVersionConfig = {
   beer_garden_version: '1.0.0',
   current_api_version: '1.0.1',
   supported_api_versions: ['1.0.0', '1.0.1'],
 }
 
-export const job: Job = {
+export const TJob: Job = {
   coalesce: false,
   error_count: 0,
   id: '123test',
@@ -32,4 +42,62 @@ export const job: Job = {
   timeout: null,
   trigger: {} as DateTrigger,
   trigger_type: 'date',
+}
+
+export const TInstance: Instance = {
+  name: 'testInstance',
+  description: 'testing an instance',
+  id: 'testinst',
+  status: 'RUNNING',
+  status_info: { heartbeat: 25 },
+  queue_type: 'queued',
+}
+
+export const TParameter: Parameter = {
+  key: 'testParam',
+  type: 'String',
+  multi: false,
+  display_name: 'test param',
+  optional: true,
+  parameters: [],
+  nullable: false,
+}
+
+export const TCommand: Command = {
+  name: 'testCommand',
+  description: 'test not blocked',
+  parameters: [TParameter],
+  command_type: 'INFO',
+  output_type: 'JSON',
+  schema: {},
+  form: {},
+  hidden: false,
+  metadata: null,
+}
+
+export const TSystem: System = {
+  name: 'testSystem',
+  description: 'testing a system',
+  version: '1.0.0',
+  namespace: 'test',
+  id: 'testsys',
+  max_instances: 5,
+  instances: [TInstance],
+  commands: [TCommand],
+  icon_name: 'trashcan',
+  display_name: 'Test System',
+  local: false,
+  template: 'template',
+}
+
+export const TBlockedCommand: BlockedCommand = {
+  namespace: 'testNamespace',
+  system: 'testSystem',
+  command: 'testCommand',
+  status: 'CONFIRMED',
+  id: 'testBlocked',
+}
+
+export const TBlocklist: BlockedList = {
+  command_publishing_blocklist: [TBlockedCommand],
 }

--- a/src/types/backend-types.ts
+++ b/src/types/backend-types.ts
@@ -56,11 +56,11 @@ export interface Parameter {
   multi: boolean
   display_name: string
   optional: boolean
+  parameters: Parameter[]
+  nullable: boolean
   default?: string | boolean | number | object
   description?: string
   choices?: Choice
-  parameters: Parameter[]
-  nullable: boolean
   maximum?: number
   minimum?: number
   regex?: string
@@ -133,9 +133,9 @@ export interface System {
   commands: Command[]
   icon_name: string
   display_name: string
-  metadata?: ObjectWithStringKeys | EmptyObject
   local: boolean
   template: string
+  metadata?: ObjectWithStringKeys | EmptyObject
 }
 
 export type TriggerType = 'cron' | 'interval' | 'date'


### PR DESCRIPTION
Closes #99 

`tableName` is now optional, can use `tableKey` in its place.

Fixes "double heading" in Command Blocklist page and adds tests for that page