### PR TITLE
#119 - Fix Command View Form button display

### DIFF
--- a/src/pages/CommandView/CommandViewForm.tsx
+++ b/src/pages/CommandView/CommandViewForm.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, ButtonGroup } from '@mui/material'
 import { ErrorSchema, FormValidation, IChangeEvent } from '@rjsf/core'
-import Form from '@rjsf/material-ui'
+import { MuiForm5 as Form } from '@rjsf/material-ui'
 import { AxiosRequestConfig } from 'axios'
 import { Snackbar } from 'components/Snackbar'
 import { useMyAxios } from 'hooks/useMyAxios'


### PR DESCRIPTION
Closes #119 

Turns out, @rjsf/material-ui is for MUI v4. We are using MUI v5. Thankfully [there is v5 support](https://github.com/rjsf-team/react-jsonschema-form/pull/2605/files#diff-e299216e91090fe3c850b4c1bbed411159d7adfe532772ea69722c14f1d0c419) shipped with @rjsf/material-ui by default. No apparent bugs swapping to MUI v5 Form.

If we ever upgrade to RJSF v5, the MUI v5 support forks off into @rjsf/mui in-order to solve a few bugs. RJSF v4 > v5 is non-trivial though, so just going with the quick fix for now since it was just a small styling problem and nothing seems to have broken.

The symptom was the "bad" buttons had an extra class that was overriding the styling. This [intermittent class injection was an artifact of MUI v4 installed by @rjsf/material-ui](https://github.com/mui/material-ui/issues/27149) clashing with the MUI v5 our app uses. The only solution is to upgrade rjsf to use MUI v5.

blue nice buttons: 

![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/107439850/190478569-c9a25230-f887-44ac-bb94-d50027c9ce3f.png)

icky buttons: 

![MicrosoftTeams-image (3)](https://user-images.githubusercontent.com/107439850/190478583-cbce8524-d06f-4fea-8df7-748348750d69.png)
