### PR TITLE
#149 - Switch to HashRouter and other release process additions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  github-release:
+    name: Github Release
+    runs-on: ubuntu-latest
+
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+# Makefile for Beer-garden UI
+
+.PHONY: clean clean-build clean-test help test deps
+.DEFAULT_GOAL := help
+
+help:
+	$(info Available actions: clean clean-build clean-test help test deps)
+
+deps: ## install javascript dependencies
+	npm install
+
+clean-build: ## Remove build
+	rm -rf build
+
+clean-all: clean-build ## clean everything
+	rm -f npm-debug.log
+	rm -f npm-error.log
+
+clean: clean-all ## alias of clean-all
+
+lint: ## check style with eslit
+	npm run lint
+
+test: ## run tests
+	npm run test
+
+package: clean ## builds distribution
+	npm run build

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,13 +6,13 @@ import { AuthContainer } from 'containers/AuthContainer'
 import { ServerConfigContainer } from 'containers/ConfigContainer'
 import { DebugContainer } from 'containers/DebugContainer'
 import ReactDOM from 'react-dom'
-import { BrowserRouter } from 'react-router-dom'
+import { HashRouter } from 'react-router-dom'
 
 import App from './App'
 import reportWebVitals from './reportWebVitals'
 
 ReactDOM.render(
-  <BrowserRouter>
+  <HashRouter>
     <ThemeProvider>
       <CssBaseline />
       <ServerConfigContainer.Provider>
@@ -23,7 +23,7 @@ ReactDOM.render(
         </DebugContainer.Provider>
       </ServerConfigContainer.Provider>
     </ThemeProvider>
-  </BrowserRouter>,
+  </HashRouter>,
   document.getElementById('root'),
 )
 


### PR DESCRIPTION
Closes #149 

This PR switches to using the `HashRouter` rather than the `BrowserRouter` to provide more flexible handling of the pathing in real world deployments.

It also includes a github action for creating releases from tags, similar to the other projects and a somewhat bare-bones Makefile that the beer-garden RPM build process will leverage to build the app.

## Testing
If you start the react app it should still work as normal, with the only real difference being that there is now a `#` in the URL before the path to the page.