### PR TITLE
#116 - hide Queue Modal table header/footer

### DIFF
--- a/src/components/QueueModal.test.tsx
+++ b/src/components/QueueModal.test.tsx
@@ -15,7 +15,6 @@ describe('Queue Modal', () => {
     await waitFor(() => {
       expect(screen.getByRole('table')).toBeInTheDocument()
     })
-    expect(screen.getByRole('heading')).toBeInTheDocument()
     expect(
       screen.getByRole('columnheader', { name: 'Name' }),
     ).toBeInTheDocument()

--- a/src/components/QueueModal.tsx
+++ b/src/components/QueueModal.tsx
@@ -119,6 +119,8 @@ const QueueModal = ({ instance }: IQueueModal) => {
           data={queueData}
           columns={useTableColumns()}
           maxrows={10}
+          hidePagination
+          hideToolbar
         />
       </Stack>
       <ModalWrapper

--- a/src/pages/SystemAdmin/SystemCardInstances.test.tsx
+++ b/src/pages/SystemAdmin/SystemCardInstances.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { TInstance, TInstance2 } from 'test/test-values'
+import { AllProviders } from 'test/testMocks'
+
+import SystemCardInstances from './SystemCardInstances'
+
+describe('SystemCard actions', () => {
+  test('renders a menu button per instance', async () => {
+    render(
+      <AllProviders>
+        <SystemCardInstances
+          instances={[TInstance, TInstance2]}
+          fileHeader={'TestNamespace'}
+        />
+      </AllProviders>,
+    )
+    expect(screen.getByText('testInstance')).toBeInTheDocument()
+    expect(screen.getByText('secondInstance')).toBeInTheDocument()
+  })
+
+  test('opens queue modal', async () => {
+    render(
+      <AllProviders>
+        <SystemCardInstances
+          instances={[TInstance]}
+          fileHeader={'TestNamespace'}
+        />
+      </AllProviders>,
+    )
+    fireEvent.click(screen.getByText('testInstance'))
+    fireEvent.click(screen.getByText('Manage Queue'))
+    expect(await screen.findByText(/Queue Manager:/)).toBeInTheDocument()
+  })
+
+  test('opens log modal', async () => {
+    render(
+      <AllProviders>
+        <SystemCardInstances
+          instances={[TInstance]}
+          fileHeader={'TestNamespace'}
+        />
+      </AllProviders>,
+    )
+    fireEvent.click(screen.getByText('testInstance'))
+    fireEvent.click(screen.getByText('Show Logs'))
+    expect(await screen.findByText(/Logs for/)).toBeInTheDocument()
+  })
+})

--- a/src/test/test-values.ts
+++ b/src/test/test-values.ts
@@ -54,6 +54,15 @@ export const TInstance: Instance = {
   queue_type: 'queued',
 }
 
+export const TInstance2: Instance = {
+  description: 'another instance to test',
+  id: 'secondInst',
+  name: 'secondInstance',
+  status: 'INITIALIZING',
+  status_info: { heartbeat: 70 },
+  queue_type: 'queued',
+}
+
 export const TLog =
   'This is a test log\nMultiples line items\nJust to test with'
 


### PR DESCRIPTION
Closes #116 

Hides toolbar and pagination on Queue modal on System Admin page