### PR TITLE
#157 - adding coverage script

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,22 @@
   "jest": {
     "moduleNameMapper": {
       "@rjsf/core/lib/utils": "@rjsf/core/dist/cjs/utils"
-    }
+    },
+    "coveragePathIgnorePatterns": [
+      "node_modules",
+      "index.ts",
+      "<rootDir>/src/test",
+      "<rootDir>/src/types"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 20,
+        "functions": 30,
+        "lines": 50,
+        "statements": 50
+      }
+    },
+    "coverageReporters": ["text-summary", "html"]
   },
   "proxy": "http://localhost:2337",
   "scripts": {
@@ -112,6 +127,7 @@
     "prepare": "husky install",
     "start": "PORT=4000 BROWSER=none react-app-rewired start",
     "test": "NODE_ENV=test CI=true react-app-rewired test",
+    "test-coverage": "NODE_ENV=test CI=true react-app-rewired test -- --coverage",
     "test-watch": "NODE_ENV=test react-app-rewired test"
   }
 }


### PR DESCRIPTION
Closes #157 

Configures code coverage for Jest and adds `test-coverage` script to package.json. Made a separate script instead of attaching to main test script as coverage causes tests to take longer to run. Outputs text summary in console and generates HTML report in `/coverage` accessible by opening the index.html file in your browser of choice.