### PR TITLE
#152 - Fix request view page auto-refetch

### DIFF
--- a/src/pages/RequestView/RequestView.test.tsx
+++ b/src/pages/RequestView/RequestView.test.tsx
@@ -1,0 +1,173 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import * as useAxios from 'axios-hooks'
+import WS from 'jest-websocket-mock'
+import Router from 'react-router-dom'
+import { TRequest, TRequestInProgress } from 'test/test-values'
+import { AllProviders } from 'test/testMocks'
+
+import { RequestView } from './RequestView'
+jest.mock('./RequestViewTable', () => ({
+  RequestViewTable: () => {
+    const MockTable = <div data-testid="request-view-table" />
+    return MockTable
+  },
+}))
+
+jest.mock('./RequestViewOutput', () => ({
+  RequestViewOutput: () => {
+    const MockOutput = <div data-testid="request-view-output" />
+    return MockOutput
+  },
+}))
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+}))
+
+jest.mock('axios-hooks', () => ({
+  ...jest.requireActual('axios-hooks'),
+  useAxios: jest.fn(),
+}))
+
+describe('RequestView', () => {
+  let server: WS
+
+  beforeEach(() => {
+    server = new WS('ws://localhost:2337/api/v1/socket/events')
+  })
+
+  afterEach(() => {
+    WS.clean()
+  })
+
+  afterAll(() => {
+    jest.unmock('./RequestViewTable')
+    jest.unmock('./RequestViewOutput')
+    jest.unmock('react-router-dom')
+    jest.unmock('axios-hooks')
+    jest.clearAllMocks()
+  })
+
+  test('renders Request View page with contents', async () => {
+    const mockId = '1234'
+    const mockFetch = jest.fn()
+    const mockResponse = Object.assign({}, TRequest, { id: mockId })
+    jest.spyOn(Router, 'useParams').mockReturnValue({ id: mockId })
+    jest
+      .spyOn(useAxios, 'default')
+      .mockReturnValue([
+        { data: mockResponse, loading: false, error: null },
+        mockFetch,
+        jest.fn(),
+      ])
+
+    render(
+      <AllProviders>
+        <RequestView />
+      </AllProviders>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Request View')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText(mockId)).toBeInTheDocument()
+    expect(screen.getByText('remake request')).toBeInTheDocument()
+    expect(screen.getByTestId('request-view-table')).toBeInTheDocument()
+    expect(screen.getByTestId('request-view-output')).toBeInTheDocument()
+    expect(screen.getByText('Parameters')).toBeInTheDocument()
+  })
+
+  test('refetches page contents when REQUEST_COMPLETED event occurs and requestId matches', async () => {
+    const mockId = '1234'
+    const mockFetch = jest.fn()
+    const mockResponse = Object.assign({}, TRequestInProgress, { id: mockId })
+
+    const mockEvent = {
+      name: 'REQUEST_COMPLETED',
+      payload: Object.assign({}, TRequest, { id: mockId }),
+    }
+
+    const mockMessage = JSON.stringify(mockEvent)
+
+    jest.spyOn(Router, 'useParams').mockReturnValue({ id: mockId })
+    jest
+      .spyOn(useAxios, 'default')
+      .mockReturnValue([
+        { data: mockResponse, loading: false, error: null },
+        mockFetch,
+        jest.fn(),
+      ])
+
+    render(
+      <AllProviders>
+        <RequestView />
+      </AllProviders>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Request View')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText(mockId)).toBeInTheDocument()
+    expect(screen.getByText('remake request')).toBeInTheDocument()
+    expect(screen.getByTestId('request-view-table')).toBeInTheDocument()
+    expect(screen.getByTestId('request-view-output')).toBeInTheDocument()
+    expect(screen.getByText('Parameters')).toBeInTheDocument()
+
+    server.send(mockMessage)
+
+    expect(mockFetch).toBeCalledTimes(1)
+  })
+
+  test('does not refetch page contents when REQUEST_COMPLETED event occurs and requestId does not match', async () => {
+    const mockId = '1234'
+    const mockFetch = jest.fn()
+    const mockResponse = Object.assign({}, TRequestInProgress, { id: mockId })
+
+    const mockEvent = {
+      name: 'REQUEST_COMPLETED',
+      payload: Object.assign({}, TRequest, { id: mockId }),
+    }
+
+    const mockEventOther = {
+      name: 'REQUEST_COMPLETED',
+      payload: Object.assign({}, TRequest, { id: '5678' }),
+    }
+
+    const mockMessage = JSON.stringify(mockEvent)
+    const mockMessageOther = JSON.stringify(mockEventOther)
+
+    jest.spyOn(Router, 'useParams').mockReturnValue({ id: mockId })
+    jest
+      .spyOn(useAxios, 'default')
+      .mockReturnValue([
+        { data: mockResponse, loading: false, error: null },
+        mockFetch,
+        jest.fn(),
+      ])
+
+    render(
+      <AllProviders>
+        <RequestView />
+      </AllProviders>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Request View')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText(mockId)).toBeInTheDocument()
+    expect(screen.getByText('remake request')).toBeInTheDocument()
+    expect(screen.getByTestId('request-view-table')).toBeInTheDocument()
+    expect(screen.getByTestId('request-view-output')).toBeInTheDocument()
+    expect(screen.getByText('Parameters')).toBeInTheDocument()
+
+    server.send(mockMessageOther)
+
+    server.send(mockMessage)
+
+    expect(mockFetch).toBeCalledTimes(1)
+  })
+})

--- a/src/pages/RequestView/RequestViewOutput.test.tsx
+++ b/src/pages/RequestView/RequestViewOutput.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { TRequest } from 'test/test-values'
+import { AllProviders } from 'test/testMocks'
+
+import { RequestViewOutput } from './RequestViewOutput'
+
+describe('RequestViewOutput', () => {
+  const mockSetState = jest.fn()
+  window.URL.createObjectURL = jest.fn(() => 'url')
+  const mockTheme = 'dark'
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('renders output card with contents', async () => {
+    const requestParams = {
+      output: 'output', 
+      status: 'SUCCESS'
+    }
+
+    const mockRequestSuccess = Object.assign({}, TRequest, requestParams)
+
+    render(
+      <AllProviders>
+        <RequestViewOutput
+          request={mockRequestSuccess}
+          expandParameter={false}
+          expandOutput={false}
+          setExpandOutput={mockSetState}
+          theme={mockTheme}
+        />
+      </AllProviders>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Output')).toBeInTheDocument()
+    })
+
+    expect(screen.getByLabelText('download output')).toBeInTheDocument()
+    expect(screen.getByLabelText('expand output')).toBeInTheDocument()
+
+    const expectedOutput = requestParams.output
+    expect(screen.getByText(expectedOutput)).toBeInTheDocument()
+  })
+})

--- a/src/pages/RequestView/RequestViewOutput.tsx
+++ b/src/pages/RequestView/RequestViewOutput.tsx
@@ -1,0 +1,97 @@
+import {
+  Download as DownloadIcon,
+  ExpandLess as ExpandLessIcon,
+  ExpandMore as ExpandMoreIcon,
+} from '@mui/icons-material'
+import {
+  Card,
+  CardActions,
+  CardContent,
+  FormControlLabel,
+  IconButton,
+  Link,
+  Switch,
+  Typography,
+} from '@mui/material'
+import { SupportedColorScheme } from '@mui/material/styles'
+import { Divider } from 'components/Divider'
+import { outputFormatted } from 'pages/RequestView/requestViewHelpers'
+import { Dispatch, SetStateAction } from 'react'
+import { useState } from 'react'
+import { Request } from 'types/backend-types'
+
+interface RequestViewOutputProps {
+  request: Request
+  expandParameter: boolean
+  expandOutput: boolean
+  setExpandOutput: Dispatch<SetStateAction<boolean>>
+  theme: SupportedColorScheme
+}
+
+const RequestViewOutput = ({
+  request,
+  expandParameter,
+  expandOutput,
+  setExpandOutput,
+  theme,
+}: RequestViewOutputProps) => {
+  const [showAsRawData, setShowAsRawData] = useState(false)
+
+  const downloadUrl = window.URL.createObjectURL(
+    new Blob([request?.output || '']),
+  )
+
+  return (
+    <Card sx={{ width: 1 }}>
+      <CardActions>
+        <Typography style={{ flex: 1 }} variant="h6">
+          Output
+        </Typography>
+        {!['HTML', 'JSON'].includes(request.output_type) ? null : (
+          <FormControlLabel
+            control={
+              <Switch
+                color="secondary"
+                checked={!showAsRawData}
+                onChange={() => {
+                  setShowAsRawData(!showAsRawData)
+                }}
+                inputProps={{ 'aria-label': 'controlled' }}
+              />
+            }
+            label="Formatted"
+          />
+        )}
+        <Link
+          href={downloadUrl}
+          download={`${request.id}.${
+            ['STRING', null].includes(request.output_type)
+              ? 'txt'
+              : request.output_type.toLowerCase()
+          }`}
+        >
+          <IconButton size="small" aria-label="download output">
+            <DownloadIcon />
+          </IconButton>
+        </Link>
+        <IconButton
+          size="small"
+          onClick={() => setExpandOutput(!expandOutput)}
+          aria-label="expand output"
+        >
+          {expandParameter || expandOutput ? (
+            <ExpandLessIcon />
+          ) : (
+            <ExpandMoreIcon />
+          )}
+        </IconButton>
+      </CardActions>
+      <Divider />
+      <CardContent>
+        {outputFormatted(request, theme, showAsRawData)}
+      </CardContent>
+    </Card>
+  )
+}
+
+export { RequestViewOutput }

--- a/src/test/test-values.ts
+++ b/src/test/test-values.ts
@@ -7,6 +7,7 @@ import {
   Job,
   Parameter,
   Queue,
+  Request,
   RequestTemplate,
   System,
 } from 'types/backend-types'
@@ -123,4 +124,43 @@ export const TBlockedCommand: BlockedCommand = {
 
 export const TBlocklist: BlockedList = {
   command_publishing_blocklist: [TBlockedCommand],
+}
+
+export const TRequest: Request = {
+  children: [],
+  command: 'command',
+  command_type: '',
+  comment: null,
+  created_at: 0,
+  error_class: null,
+  id: '',
+  instance_name: '',
+  namespace: 'namespace',
+  output: 'output',
+  output_type: 'STRING',
+  parameters: [],
+  parent: null,
+  status: 'SUCCESS',
+  system: 'system',
+  system_version: 'system_version',
+  updated_at: 0
+}
+
+export const TRequestInProgress: Request = {
+  children: [],
+  command: 'command',
+  command_type: '',
+  comment: null,
+  created_at: 0,
+  error_class: null,
+  id: '',
+  instance_name: '',
+  namespace: 'namespace',
+  output_type: 'STRING',
+  parameters: [],
+  parent: null,
+  status: 'IN PROGRESS',
+  system: 'system',
+  system_version: 'system_version',
+  updated_at: 0
 }


### PR DESCRIPTION
Closes #152 

This PR fixes the functionality on the Request View page, such that if you open the Request View page for a job that is still In Progress, once the job is Complete, the page should automatically update with status: SUCCESS and the output.
 
## Test Instructions
* On the Systems page, run some commands that take some time (such as the sleep command in the sleeper system)
* Once you hit execute, you should be directed to the Request View page where the status is In Progress and the Output card has a loading spinner.
* After the command is complete, the page should automatically update with the new status (SUCCESS or ERROR) and the Output card should now contain the output