### PR TITLE
Issue 170 - remove references to any type

### DIFF
--- a/src/components/Table/filters/SelectionColumnFilter.tsx
+++ b/src/components/Table/filters/SelectionColumnFilter.tsx
@@ -14,8 +14,7 @@ const SelectionColumnFilter = ({
   },
 }: FilterProps<ObjectWithStringKeys>) => {
   const options = useMemo(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let options: Set<any>
+    let options: Set<string>
 
     if (selectionOptions) {
       options = new Set(selectionOptions)

--- a/src/components/Table/filters/numericTextFilter.tsx
+++ b/src/components/Table/filters/numericTextFilter.tsx
@@ -29,16 +29,6 @@ function parseValue(filterValue: FilterValue) {
   return defaultComparator
 }
 
-// const numericTextFilter = <T extends ObjectWithStringKeys>(
-//   rows: Array<Row<T>>,
-//   id: Array<IdType<T>>,
-//   filterValue: FilterValue,
-// ): Array<Row<T>> => {
-//   const comparator = parseValue(filterValue)
-
-//   return rows.filter((row) => comparator(row.values[id[0]]))
-// }
-
 function numericTextFilter<T extends ObjectWithStringKeys>(
   rows: Array<Row<T>>,
   id: Array<IdType<T>>,
@@ -48,8 +38,5 @@ function numericTextFilter<T extends ObjectWithStringKeys>(
 
   return rows.filter((row) => comparator(row.values[id[0]]))
 }
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-// numericTextFilter.autoRemove = (val: any) => !val
 
 export { numericTextFilter }


### PR DESCRIPTION
Closes #170 

Removes the last references to any except one in a type definition file which is a logical use. Going forward during reviews, remember to not introduce `any` type if it can be avoided.