### PR TITLE
115 point open api link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "react-router-dom": "^6.2.2",
         "react-scripts": "^5.0.1",
         "react-table": "^7.8.0",
-        "swagger-ui-dist": "^4.12.0",
+        "swagger-ui-dist": "^3.52.5",
         "typescript": "^4.7.4",
         "unstated-next": "^1.1.0",
         "web-vitals": "^2.1.4",
@@ -19080,9 +19080,9 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.14.0.tgz",
-      "integrity": "sha512-TBzhheU15s+o54Cgk9qxuYcZMiqSm/SkvKnapoGHOF66kz0Y5aGjpzj5BT/vpBbn6rTPJ9tUYXQxuDWfsjiGMw=="
+      "version": "3.52.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.52.5.tgz",
+      "integrity": "sha512-8z18eX8G/jbTXYzyNIaobrnD7PSN7yU/YkSasMmajrXtw0FGS64XjrKn5v37d36qmU3o1xLeuYnktshRr7uIFw=="
     },
     "node_modules/symbol-observable": {
       "version": "1.2.0",
@@ -34418,9 +34418,9 @@
       }
     },
     "swagger-ui-dist": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.14.0.tgz",
-      "integrity": "sha512-TBzhheU15s+o54Cgk9qxuYcZMiqSm/SkvKnapoGHOF66kz0Y5aGjpzj5BT/vpBbn6rTPJ9tUYXQxuDWfsjiGMw=="
+      "version": "3.52.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.52.5.tgz",
+      "integrity": "sha512-8z18eX8G/jbTXYzyNIaobrnD7PSN7yU/YkSasMmajrXtw0FGS64XjrKn5v37d36qmU3o1xLeuYnktshRr7uIFw=="
     },
     "symbol-observable": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,10 @@
         "statements": 50
       }
     },
-    "coverageReporters": ["text-summary", "html"]
+    "coverageReporters": [
+      "text-summary",
+      "html"
+    ]
   },
   "proxy": "http://localhost:2337",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-router-dom": "^6.2.2",
     "react-scripts": "^5.0.1",
     "react-table": "^7.8.0",
-    "swagger-ui-dist": "^4.12.0",
+    "swagger-ui-dist": "^3.52.5",
     "typescript": "^4.7.4",
     "unstated-next": "^1.1.0",
     "web-vitals": "^2.1.4",


### PR DESCRIPTION
Closes #115 
 
This PR fixes the Swagger UI link so that it loads the spec for the beergarden API instead of the petstore. This involved downgrading the swagger version so that ?url= was an allowed parameter
 
## Test Instructions
* Open the menu and click Open API Documentation
* You should be navigated to the Swagger UI for Beergarden (api/v1/spec)