### PR TITLE
Fix bug in stopInstance() of useInstances hook

### DIFF
--- a/src/hooks/useInstances.tsx
+++ b/src/hooks/useInstances.tsx
@@ -75,7 +75,7 @@ const useInstances = () => {
   }
 
   const stopInstance = async (id: string) => {
-    return await toggleInstance(id, 'start')
+    return await toggleInstance(id, 'stop')
   }
 
   const stopAllInstances = (system: System) => {


### PR DESCRIPTION
stopInstance() was previously starting instances. Can look in terminal to see that now it's terminating the instance