### PR TITLE
88 - Make system admin alerts responsive

### DIFF
--- a/src/hooks/useSystems.tsx
+++ b/src/hooks/useSystems.tsx
@@ -1,6 +1,7 @@
 import { AxiosRequestConfig } from 'axios'
 import useAxios from 'axios-hooks'
 import { ServerConfigContainer } from 'containers/ConfigContainer'
+import { SocketContainer } from 'containers/SocketContainer'
 import { useMyAxios } from 'hooks/useMyAxios'
 import { useEffect, useState } from 'react'
 import { System } from 'types/backend-types'
@@ -8,17 +9,31 @@ import { System } from 'types/backend-types'
 const useSystems = () => {
   const { authEnabled } = ServerConfigContainer.useContainer()
   const [systems, setSystems] = useState<System[]>([])
-  const [{ data, error }] = useAxios({
+  const [{ data, error }, refetch] = useAxios({
     url: '/api/v1/systems',
     method: 'get',
     withCredentials: authEnabled,
   })
+  const { addCallback, removeCallback } = SocketContainer.useContainer()
 
   useEffect(() => {
     if (data && !error) {
       setSystems(data)
     }
   }, [data, error])
+
+  useEffect(() => {
+    addCallback('system_updates', (event) => {
+      if (
+        event.name === 'INSTANCE_UPDATED'
+      ) {
+        refetch()
+      }
+    })
+    return () => {
+      removeCallback('system_updates')
+    }
+  }, [addCallback, removeCallback, refetch])
 
   const getSystems = () => {
     return systems

--- a/src/hooks/useSystems.tsx
+++ b/src/hooks/useSystems.tsx
@@ -25,7 +25,7 @@ const useSystems = () => {
   useEffect(() => {
     addCallback('system_updates', (event) => {
       if (
-        event.name === 'INSTANCE_UPDATED'
+        event.name === 'INSTANCE_UPDATED' || event.name === 'SYSTEM_REMOVED'
       ) {
         refetch()
       }


### PR DESCRIPTION
Closes #88 

Starting or stopping some or all instances in a system should result in color changes on the UI, such that:
* A system, instance, or namespace with at least 1 instance in STOPPED status is highlighted red
* A system, instance, or namespace with all instances in RUNNING status is highlighted green
* A system that is deleted is removed from the page

Previously, these changes were only rendered upon a user refreshing the page. Now this is done automatically.

To test:
1. Open Admin > Systems in Sidebar menu
2. Start and stop an individual instance in a system to see the change
3. Start and stop all instances in the system to see the change
4. Reload a system to see the change
5. Delete a system to see the change

Ticket for refactoring useSystems hook and adding tests here: #197 