### PR TITLE
Changed color of Text in Table

### DIFF
--- a/src/components/Table/defaults/OverflowCellRenderer.tsx
+++ b/src/components/Table/defaults/OverflowCellRenderer.tsx
@@ -7,18 +7,13 @@ const OverflowCellRenderer = ({
   cell: { value },
 }: CellProps<ObjectWithStringKeys>) => (
   <>
-    <Box
-      component="span"
-      display="flex"
-      justifyContent="left"
-    >
+    <Box component="span" display="flex" justifyContent="left">
       <OverflowTooltip
-      color="common.black"
-      variant="inherit"
-      tooltip={value}
-      text={value}
-      css={{ py: 0 }}
-    />
+        variant="inherit"
+        tooltip={value}
+        text={value}
+        css={{ py: 0 }}
+      />
     </Box>
   </>
 )


### PR DESCRIPTION
Closes #222 
I change the color of the text in the table, so it will be white or black based on which theme is actively being used. 
To test the text in the table on the systems page should now be white while in dark mode and should remain black when in light mode. 