### PR TITLE
Refactor useSystems hook to use promises

### DIFF
--- a/src/hooks/useSystems.test.tsx
+++ b/src/hooks/useSystems.test.tsx
@@ -1,0 +1,89 @@
+import { waitFor } from '@testing-library/react'
+import { renderHook } from '@testing-library/react-hooks'
+import { mockAxios } from 'test/axios-mock'
+import { TInstance, TSystem } from 'test/test-values'
+import { ConfigProviders } from 'test/testMocks'
+
+import { useSystems } from './useSystems'
+
+describe('useSystems', () => {
+  test('getSystems gets systems', async () => {
+    const { result } = renderHook(() => useSystems(), {
+      wrapper: ConfigProviders,
+    })
+    const response = await waitFor(() => {
+      return result.current.getSystems()
+    })
+    await waitFor(() => {
+      expect(response.data).toEqual([TSystem])
+    })
+  })
+
+  // message body is empty
+  test('reloadSystem reloads the system', async () => {
+    const testInstance = Object.assign({}, TInstance, { status: 'STOPPED' })
+    const testSystem = Object.assign({}, TSystem, { instances: [testInstance] })
+    mockAxios.onGet('/api/v1/systems').reply(200, [testSystem])
+
+    const { result } = renderHook(() => useSystems(), {
+      wrapper: ConfigProviders,
+    })
+    const response = await waitFor(() => {
+      return result.current.getSystems()
+    })
+    await waitFor(() => {
+      expect(response.data).toEqual([testSystem])
+    })
+    expect(response.data[0].instances[0].status).toBe('STOPPED')
+
+    // reload the system
+    const responseReload = await waitFor(() => {
+      return result.current.reloadSystem(TSystem.id)
+    })
+    await waitFor(() => {
+      expect(responseReload.data).toBe('')
+    })
+
+    mockAxios.onGet('/api/v1/systems').reply(200, [TSystem])
+
+    // confirm that system was reloaded
+    const responseAfterReload = await waitFor(() => {
+      return result.current.getSystems()
+    })
+    await waitFor(() => {
+      expect(responseAfterReload.data).toEqual([TSystem])
+    })
+    expect(responseAfterReload.data[0].instances[0].status).toBe('RUNNING')
+  })
+
+  test('deleteSystem deletes the system', async () => {
+    const { result } = renderHook(() => useSystems(), {
+      wrapper: ConfigProviders,
+    })
+    const response = await waitFor(() => {
+      return result.current.getSystems()
+    })
+    await waitFor(() => {
+      expect(response.data).toEqual([TSystem])
+    })
+
+    // delete the system
+    const responseDelete = await waitFor(() => {
+      return result.current.deleteSystem(TSystem.id)
+    })
+    await waitFor(() => {
+      expect(responseDelete.data).not.toBeDefined()
+    })
+
+    // confirm that system was deleted
+    mockAxios.onGet('/api/v1/systems').reply(200, [])
+    const responseAfterDelete = await waitFor(() => {
+      return result.current.getSystems()
+    })
+    await waitFor(() => {
+      expect(responseAfterDelete.data).toEqual([])
+    })
+
+    mockAxios.onGet('/api/v1/systems').reply(200, [TSystem])
+  })
+})

--- a/src/hooks/useSystems.tsx
+++ b/src/hooks/useSystems.tsx
@@ -1,42 +1,12 @@
 import { AxiosRequestConfig } from 'axios'
 import useAxios from 'axios-hooks'
 import { ServerConfigContainer } from 'containers/ConfigContainer'
-import { SocketContainer } from 'containers/SocketContainer'
 import { useMyAxios } from 'hooks/useMyAxios'
-import { useEffect, useState } from 'react'
-import { System } from 'types/backend-types'
 
 const useSystems = () => {
   const { authEnabled } = ServerConfigContainer.useContainer()
   const { axiosManualOptions } = useMyAxios()
   const [, execute] = useAxios({}, axiosManualOptions)
-  const [systems, setSystems] = useState<System[]>([])
-  const [{ data, error }, refetch] = useAxios({
-    url: '/api/v1/systems',
-    method: 'get',
-    withCredentials: authEnabled,
-  })
-  const { addCallback, removeCallback } = SocketContainer.useContainer()
-
-  useEffect(() => {
-    if (data && !error) {
-      setSystems(data)
-    }
-  }, [data, error])
-
-  useEffect(() => {
-    addCallback('system_updates', (event) => {
-      if (
-        event.name === 'INSTANCE_UPDATED' ||
-        event.name === 'SYSTEM_REMOVED'
-      ) {
-        refetch()
-      }
-    })
-    return () => {
-      removeCallback('system_updates')
-    }
-  }, [addCallback, removeCallback, refetch])
 
   const getSystems = () => {
     const config: AxiosRequestConfig = {
@@ -44,19 +14,9 @@ const useSystems = () => {
       method: 'get',
       withCredentials: authEnabled,
     }
+
     return execute(config)
   }
-
-  return {
-    getSystems,
-    systems,
-  }
-}
-
-const useManipulateSystem = () => {
-  const { authEnabled } = ServerConfigContainer.useContainer()
-  const { axiosManualOptions } = useMyAxios()
-  const [, execute] = useAxios({}, axiosManualOptions)
 
   const reloadSystem = (systemId: string) => {
     const config: AxiosRequestConfig = {
@@ -66,7 +26,7 @@ const useManipulateSystem = () => {
       data: { operation: 'reload' },
     }
 
-    execute(config)
+    return execute(config)
   }
 
   const deleteSystem = (systemId: string) => {
@@ -76,10 +36,14 @@ const useManipulateSystem = () => {
       withCredentials: authEnabled,
     }
 
-    execute(config)
+    return execute(config)
   }
 
-  return { reloadSystem, deleteSystem }
+  return {
+    getSystems,
+    reloadSystem,
+    deleteSystem,
+  }
 }
 
-export { useManipulateSystem, useSystems }
+export { useSystems }

--- a/src/pages/JobCreate/JobCreateSystemsTable/JobCreateSystemsTable.tsx
+++ b/src/pages/JobCreate/JobCreateSystemsTable/JobCreateSystemsTable.tsx
@@ -1,6 +1,9 @@
+import { Snackbar } from 'components/Snackbar'
 import { Table } from 'components/Table'
-import { PropsWithChildren } from 'react'
+import { useSystems } from 'hooks/useSystems'
+import { PropsWithChildren, useEffect, useState } from 'react'
 import { System } from 'types/backend-types'
+import { SnackbarState } from 'types/custom-types'
 
 import { useSystemColumns, useSystemsData } from './data'
 
@@ -11,15 +14,37 @@ const JobCreateSystemsTable = ({
   systemSetter,
   children,
 }: PropsWithChildren<JobCreateSystemTableProps>) => {
+  const [systems, setSystems] = useState<System[]>([])
+  const [alert, setAlert] = useState<SnackbarState | undefined>(undefined)
+  const { getSystems } = useSystems()
+
+  useEffect(() => {
+    getSystems()
+      .then((response) => {
+        setSystems(response.data)
+      })
+      .catch((e) => {
+        setAlert({
+          severity: 'error',
+          message: e,
+          doNotAutoDismiss: true,
+        })
+      })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   return (
-    <Table
-      tableKey="JobSystems"
-      data={useSystemsData(systemSetter)}
-      columns={useSystemColumns()}
-      showGlobalFilter
-    >
-      {children}
-    </Table>
+    <>
+      <Table
+        tableKey="JobSystems"
+        data={useSystemsData(systems, systemSetter)}
+        columns={useSystemColumns()}
+        showGlobalFilter
+      >
+        {children}
+      </Table>
+      {alert && <Snackbar status={alert} />}
+    </>
   )
 }
 

--- a/src/pages/JobCreate/JobCreateSystemsTable/data.tsx
+++ b/src/pages/JobCreate/JobCreateSystemsTable/data.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@mui/material'
 import { DefaultCellRenderer } from 'components/Table/defaults'
-import { useSystems } from 'hooks/useSystems'
 import { useCallback, useMemo } from 'react'
 import { Column } from 'react-table'
 import { System } from 'types/backend-types'
@@ -45,12 +44,14 @@ const useSystemMapper = (
   )
 }
 
-const useSystemsData = (systemSetter: (system: System) => void) => {
-  const { systems } = useSystems()
+const useSystemsData = (
+  systems: System[],
+  systemSetter: (system: System) => void,
+) => {
   const systemMapper = useSystemMapper(systemSetter)
-
   return (systems as System[]).map(systemMapper)
 }
+
 const useSystemColumns = () => {
   return useMemo<Column<JobCreateSystemsTableData>[]>(
     () => [

--- a/src/pages/JobUpdate/UpdateJobView.tsx
+++ b/src/pages/JobUpdate/UpdateJobView.tsx
@@ -16,17 +16,20 @@ import { Job, System } from 'types/backend-types'
 const UpdateJobView = () => {
   const [system, setSystem] = useState<System>()
   const { debugEnabled } = ServerConfigContainer.useContainer()
-  const { systems } = useSystems()
+  const { getSystems } = useSystems()
   const { namespace, systemName, version, jobName } = useParams()
   const { isJob, job } = useJobRequestCreation()
 
   useEffect(() => {
-    const foundSystem = systems.find(
-      (systemCheck) => systemCheck.name === systemName,
-    )
-    if (foundSystem) {
-      setSystem(foundSystem)
-    }
+    getSystems().then((response) => {
+      const systems = response.data
+      const foundSystem = systems.find(
+        (systemCheck: System) => systemCheck.name === systemName,
+      )
+      if (foundSystem) {
+        setSystem(foundSystem)
+      }
+    })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [systemName])
 

--- a/src/pages/SystemAdmin/NamespaceCard.test.tsx
+++ b/src/pages/SystemAdmin/NamespaceCard.test.tsx
@@ -1,12 +1,23 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import WS from 'jest-websocket-mock'
 import { mockAxios, regexUsers } from 'test/axios-mock'
-import { TServerAuthConfig, TSystem } from 'test/test-values'
+import { TInstance, TServerAuthConfig, TSystem } from 'test/test-values'
 import { LoggedInProviders } from 'test/testMocks'
 import { TAdmin, TUser } from 'test/user-test-values'
 
 import { NamespaceCard } from './NamespaceCard'
 
 describe('NamespaceCard', () => {
+  let server: WS
+
+  beforeEach(() => {
+    server = new WS('ws://localhost:2337/api/v1/socket/events')
+  })
+
+  afterEach(() => {
+    WS.clean()
+  })
+
   test('renders card if permission', async () => {
     mockAxios.onGet('/config').reply(200, TServerAuthConfig)
     mockAxios.onGet(regexUsers).reply(200, TAdmin)
@@ -18,6 +29,25 @@ describe('NamespaceCard', () => {
     await waitFor(() => {
       expect(screen.getByText(TSystem.namespace)).toBeInTheDocument()
     })
+    const namespaceTitle = screen.getByTitle('Click to collapse')
+    expect(namespaceTitle).toHaveClass('MuiAlert-outlinedSuccess')
+    expect(
+      within(namespaceTitle).getByText(TSystem.namespace),
+    ).toBeInTheDocument()
+
+    expect(screen.getByText(TSystem.name)).toBeInTheDocument()
+    expect(screen.getByText(TSystem.version)).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('link', { name: 'View instance commands' }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'start' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'stop' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'reload' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'delete' })).toBeInTheDocument()
+
+    expect(screen.getByText(TSystem.description)).toBeInTheDocument()
+    expect(screen.getByText(TInstance.name)).toBeInTheDocument()
   })
 
   test('does not render if no permission', async () => {
@@ -31,5 +61,119 @@ describe('NamespaceCard', () => {
     await waitFor(() => {
       expect(screen.queryByText(TSystem.namespace)).not.toBeInTheDocument()
     })
+  })
+
+  test('Namespace Card updated on INSTANCE_UPDATED event', async () => {
+    const mockInstance = Object.assign({}, TInstance, {
+      status: 'STOPPED',
+    })
+
+    const mockSystem = Object.assign({}, TSystem, { instances: [mockInstance] })
+
+    render(
+      <LoggedInProviders>
+        <NamespaceCard namespace={TSystem.namespace} />
+      </LoggedInProviders>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(TSystem.namespace)).toBeInTheDocument()
+    })
+
+    const namespaceTitleBefore = screen.getByTitle('Click to collapse')
+    expect(namespaceTitleBefore).toHaveClass('MuiAlert-outlinedSuccess')
+    expect(within(namespaceTitleBefore).getByText('test')).toBeInTheDocument()
+
+    mockAxios.onGet('/api/v1/systems').reply(200, [mockSystem])
+
+    // send instance updated event to stop an instance
+    const mockEvent = {
+      name: 'INSTANCE_UPDATED',
+      payload: mockInstance,
+    }
+    server.send(JSON.stringify(mockEvent))
+
+    await waitFor(() => {
+      expect(screen.getByText(TSystem.namespace)).toBeInTheDocument()
+    })
+
+    const namespaceTitleAfter = screen.getByTitle('Click to collapse')
+    expect(namespaceTitleAfter).toHaveClass('MuiAlert-outlinedError')
+    expect(within(namespaceTitleAfter).getByText('test')).toBeInTheDocument()
+
+    mockAxios.onGet('/api/v1/systems').reply(200, [TSystem])
+  })
+
+  test('Namespace Card updated on SYSTEM_REMOVED event', async () => {
+    render(
+      <LoggedInProviders>
+        <NamespaceCard namespace={TSystem.namespace} />
+      </LoggedInProviders>,
+    )
+    await waitFor(() => {
+      expect(screen.getByText(TSystem.namespace)).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('testSystem')).toBeInTheDocument()
+    expect(screen.getByText('1.0.0')).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'View instance commands' }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'start' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'stop' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'reload' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'delete' })).toBeInTheDocument()
+    expect(screen.getByText('testing a system')).toBeInTheDocument()
+    expect(screen.getByText('testInstance')).toBeInTheDocument()
+
+    mockAxios.onGet('/api/v1/systems').reply(200, [])
+
+    // send instance updated event to remove a system
+    const mockEvent = {
+      name: 'SYSTEM_REMOVED',
+      payload: TSystem,
+    }
+    server.send(JSON.stringify(mockEvent))
+
+    await waitFor(() => {
+      expect(screen.getByText('test')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('testSystem')).not.toBeInTheDocument()
+    expect(screen.queryByText('1.0.0')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: 'View instance commands' }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'start' }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'stop' }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'reload' }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'delete' }),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText('testing a system')).not.toBeInTheDocument()
+    expect(screen.queryByText('testInstance')).not.toBeInTheDocument()
+    mockAxios.onGet('/api/v1/systems').reply(200, [TSystem])
+  })
+
+  test('Alert is shown on error from getSystems()', async () => {
+    mockAxios.onGet('/api/v1/systems').reply(404)
+
+    render(
+      <LoggedInProviders>
+        <NamespaceCard namespace={TSystem.namespace} />
+      </LoggedInProviders>,
+    )
+
+    await waitFor(() => {
+      const errorMessage = 'ERROR: Error: Request failed with status code 404'
+      expect(screen.getByText(errorMessage)).toBeInTheDocument()
+    })
+
+    mockAxios.onGet('/api/v1/systems').reply(200, [TSystem])
   })
 })

--- a/src/pages/SystemAdmin/NamespaceCard.tsx
+++ b/src/pages/SystemAdmin/NamespaceCard.tsx
@@ -6,7 +6,9 @@ import {
   Grid,
   Typography,
 } from '@mui/material'
+import { Snackbar } from 'components/Snackbar'
 import { PermissionsContainer } from 'containers/PermissionsContainer'
+import { SocketContainer } from 'containers/SocketContainer'
 import { useSystems } from 'hooks/useSystems'
 import {
   alertStyle,
@@ -17,41 +19,82 @@ import {
 import SystemCard from 'pages/SystemAdmin/SystemAdminCard'
 import { useEffect, useState } from 'react'
 import { System } from 'types/backend-types'
+import { SnackbarState } from 'types/custom-types'
 
 const NamespaceCard = ({ namespace }: { namespace: string }) => {
   const { hasSystemPermission } = PermissionsContainer.useContainer()
-  const systemClient = useSystems()
-  const systems = systemClient.systems
+  const { getSystems } = useSystems()
   const [expanded, setExpanded] = useState(true)
   const [permission, setPermission] = useState(false)
+  const [filteredSystems, setFilteredSystems] = useState<System[]>([])
+  const [sortedSystems, setSortedSystems] = useState<{
+    [key: string]: System[]
+  }>({})
+  const [alert, setAlert] = useState<SnackbarState | undefined>(undefined)
+  const { addCallback, removeCallback } = SocketContainer.useContainer()
+
+  const fetchPermissions = (systems: System[]) => {
+    if (systems[0]) {
+      hasSystemPermission('system:update', namespace, systems[0].id).then(
+        (response) => {
+          setPermission(response || false)
+        },
+      )
+    }
+  }
+
+  const updateSystems = () => {
+    getSystems()
+      .then((response) => {
+        return response.data
+      })
+      .then((systems) => {
+        const filtered = systems.filter(
+          (system: System) => system.namespace === namespace,
+        )
+        setFilteredSystems(filtered)
+        return filtered
+      })
+      .then((filtered) => {
+        fetchPermissions(filtered)
+        return filtered
+      })
+      .then((filtered) => {
+        const sorted = sortSystems(filtered)
+        setSortedSystems(sorted)
+      })
+      .catch((e) => {
+        setAlert({
+          severity: 'error',
+          message: e,
+          doNotAutoDismiss: true,
+        })
+      })
+  }
+
+  useEffect(() => {
+    addCallback('system_updates', (event) => {
+      if (
+        event.name === 'INSTANCE_UPDATED' ||
+        event.name === 'SYSTEM_REMOVED'
+      ) {
+        updateSystems()
+      }
+    })
+    return () => {
+      removeCallback('system_updates')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [addCallback, removeCallback])
+
+  useEffect(() => {
+    updateSystems()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const handleExpandClick = () => {
     setExpanded(!expanded)
   }
-
-  const filteredSystem = systems.filter(
-    (system: System) => system.namespace === namespace,
-  )
-  useEffect(() => {
-    const fetchPermission = async () => {
-      if (filteredSystem[0]) {
-        const permCheck = await hasSystemPermission(
-          'system:update',
-          namespace,
-          filteredSystem[0].id,
-        )
-        setPermission(permCheck || false)
-      }
-    }
-    fetchPermission()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [namespace, filteredSystem[0]])
-
-  if (!systems) {
-    return <></>
-  }
-
-  const sortedSystems = sortSystems(filteredSystem)
 
   return (
     <>
@@ -63,8 +106,8 @@ const NamespaceCard = ({ namespace }: { namespace: string }) => {
               ...alertStyle,
               backgroundColor: 'primary.main',
             }}
-            icon={systemIcon(filteredSystem) ? undefined : false}
-            severity={systemsSeverity(filteredSystem)}
+            icon={systemIcon(filteredSystems) ? undefined : false}
+            severity={systemsSeverity(filteredSystems)}
             onClick={handleExpandClick}
             title="Click to collapse"
           >
@@ -98,6 +141,7 @@ const NamespaceCard = ({ namespace }: { namespace: string }) => {
           </Collapse>
         </Card>
       )}
+      {alert && <Snackbar status={alert} />}
     </>
   )
 }

--- a/src/pages/SystemAdmin/SystemAdminCard.tsx
+++ b/src/pages/SystemAdmin/SystemAdminCard.tsx
@@ -21,8 +21,9 @@ import {
   Typography,
 } from '@mui/material'
 import OverflowTooltip from 'components/OverflowTooltip'
+import { Snackbar } from 'components/Snackbar'
 import { useInstances } from 'hooks/useInstances'
-import { useManipulateSystem } from 'hooks/useSystems'
+import { useSystems } from 'hooks/useSystems'
 import {
   alertStyle,
   instanceIcon,
@@ -33,144 +34,171 @@ import SystemCardInstances from 'pages/SystemAdmin/SystemCardInstances'
 import { useState } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
 import { System } from 'types/backend-types'
+import { SnackbarState } from 'types/custom-types'
 
 const SystemAdminCard = ({ systems }: { systems: System[] }) => {
   const { startAllInstances, stopAllInstances } = useInstances()
-  const { reloadSystem, deleteSystem } = useManipulateSystem()
+  const { reloadSystem, deleteSystem } = useSystems()
   const [systemIndex, setSystemIndex] = useState(0)
+  const [alert, setAlert] = useState<SnackbarState | undefined>(undefined)
 
   const handleChange = (event: SelectChangeEvent) => {
     setSystemIndex(parseInt(event.target.value))
   }
 
+  const handleReloadSystem = (systemId: string) => {
+    reloadSystem(systemId).catch((e) => {
+      setAlert({
+        severity: 'error',
+        message: e,
+        doNotAutoDismiss: true,
+      })
+    })
+  }
+
+  const handleDeleteSystem = (systemId: string) => {
+    deleteSystem(systemId).catch((e) => {
+      setAlert({
+        severity: 'error',
+        message: e,
+        doNotAutoDismiss: true,
+      })
+    })
+  }
+
   return (
-    <Card sx={{ width: 200 }}>
-      <Alert
-        variant="outlined"
-        sx={{
-          ...alertStyle,
-          backgroundColor: 'primary.main',
-        }}
-        icon={instanceIcon(systems[systemIndex].instances) ? undefined : false}
-        severity={systemsSeverity(systems)}
-      >
-        <OverflowTooltip
-          color="common.white"
-          variant="h6"
-          tooltip={systems[systemIndex].name}
-          text={systems[systemIndex].name}
-          css={{ py: 0 }}
+    <>
+      <Card sx={{ width: 200 }}>
+        <Alert
+          variant="outlined"
+          sx={{
+            ...alertStyle,
+            backgroundColor: 'primary.main',
+          }}
+          icon={
+            instanceIcon(systems[systemIndex].instances) ? undefined : false
+          }
+          severity={systemsSeverity(systems)}
+        >
+          <OverflowTooltip
+            color="common.white"
+            variant="h6"
+            tooltip={systems[systemIndex].name}
+            text={systems[systemIndex].name}
+            css={{ py: 0 }}
+          />
+        </Alert>
+        <CardContent>
+          <Grid justifyContent="center" container>
+            <Grid item key="selector">
+              <FormControl sx={{ m: 0.1, py: 0.1 }} size="small">
+                <Select
+                  variant="outlined"
+                  error={systemIcon(systems)}
+                  value={systemIndex.toString()}
+                  onChange={handleChange}
+                  sx={{ py: 0.1 }}
+                >
+                  {systems.map((system, index) => (
+                    <MenuItem key={system.version} value={index} dense divider>
+                      <Alert
+                        sx={{ ...alertStyle, py: 0.1 }}
+                        severity={systemsSeverity([system])}
+                        icon={false}
+                      >
+                        {system.version}
+                      </Alert>
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Grid>
+            <Grid item key={`${systems[systemIndex]}Actions`}>
+              <Toolbar variant="dense" disableGutters sx={{ minHeight: 36 }}>
+                <Tooltip
+                  arrow
+                  title="View instance commands"
+                  placement="bottom-start"
+                >
+                  <IconButton
+                    size="small"
+                    component={RouterLink}
+                    to={[
+                      '/systems',
+                      systems[systemIndex].namespace,
+                      systems[systemIndex].name,
+                      systems[systemIndex].version,
+                    ].join('/')}
+                  >
+                    <LinkIcon />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip
+                  arrow
+                  title="Start all instances"
+                  placement="bottom-start"
+                >
+                  <IconButton
+                    size="small"
+                    onClick={() => startAllInstances(systems[systemIndex])}
+                    aria-label="start"
+                  >
+                    <PlayCircleFilledIcon />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip
+                  arrow
+                  title="Stop all instances"
+                  placement="bottom-start"
+                >
+                  <IconButton
+                    size="small"
+                    onClick={() => stopAllInstances(systems[systemIndex])}
+                    aria-label="stop"
+                  >
+                    <StopIcon />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip arrow title="Reload system" placement="bottom-start">
+                  <IconButton
+                    size="small"
+                    onClick={() => handleReloadSystem(systems[systemIndex].id)}
+                    aria-label="reload"
+                  >
+                    <CachedIcon />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip arrow title="Delete system" placement="bottom-start">
+                  <IconButton
+                    size="small"
+                    onClick={() => handleDeleteSystem(systems[systemIndex].id)}
+                    aria-label="delete"
+                  >
+                    <DeleteIcon />
+                  </IconButton>
+                </Tooltip>
+              </Toolbar>
+            </Grid>
+            <Grid item key="description">
+              <Typography
+                variant="body2"
+                color="textSecondary"
+                gutterBottom={false}
+                sx={{ fontSize: '13px' }}
+              >
+                {systems[systemIndex].description}
+              </Typography>
+            </Grid>
+          </Grid>
+        </CardContent>
+        <Divider variant="middle" />
+        <SystemCardInstances
+          instances={systems[systemIndex].instances}
+          fileHeader={`${systems[systemIndex].name}[${systems[systemIndex].version}]`}
         />
-      </Alert>
-      <CardContent>
-        <Grid justifyContent="center" container>
-          <Grid item key="selector">
-            <FormControl sx={{ m: 0.1, py: 0.1 }} size="small">
-              <Select
-                variant="outlined"
-                error={systemIcon(systems)}
-                value={systemIndex.toString()}
-                onChange={handleChange}
-                sx={{ py: 0.1 }}
-              >
-                {systems.map((system, index) => (
-                  <MenuItem key={system.version} value={index} dense divider>
-                    <Alert
-                      sx={{ ...alertStyle, py: 0.1 }}
-                      severity={systemsSeverity([system])}
-                      icon={false}
-                    >
-                      {system.version}
-                    </Alert>
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Grid>
-          <Grid item key={`${systems[systemIndex]}Actions`}>
-            <Toolbar variant="dense" disableGutters sx={{ minHeight: 36 }}>
-              <Tooltip
-                arrow
-                title="View instance commands"
-                placement="bottom-start"
-              >
-                <IconButton
-                  size="small"
-                  component={RouterLink}
-                  to={[
-                    '/systems',
-                    systems[systemIndex].namespace,
-                    systems[systemIndex].name,
-                    systems[systemIndex].version,
-                  ].join('/')}
-                >
-                  <LinkIcon />
-                </IconButton>
-              </Tooltip>
-              <Tooltip
-                arrow
-                title="Start all instances"
-                placement="bottom-start"
-              >
-                <IconButton
-                  size="small"
-                  onClick={() => startAllInstances(systems[systemIndex])}
-                  aria-label="start"
-                >
-                  <PlayCircleFilledIcon />
-                </IconButton>
-              </Tooltip>
-              <Tooltip
-                arrow
-                title="Stop all instances"
-                placement="bottom-start"
-              >
-                <IconButton
-                  size="small"
-                  onClick={() => stopAllInstances(systems[systemIndex])}
-                  aria-label="stop"
-                >
-                  <StopIcon />
-                </IconButton>
-              </Tooltip>
-              <Tooltip arrow title="Reload system" placement="bottom-start">
-                <IconButton
-                  size="small"
-                  onClick={() => reloadSystem(systems[systemIndex].id)}
-                  aria-label="reload"
-                >
-                  <CachedIcon />
-                </IconButton>
-              </Tooltip>
-              <Tooltip arrow title="Delete system" placement="bottom-start">
-                <IconButton
-                  size="small"
-                  onClick={() => deleteSystem(systems[systemIndex].id)}
-                  aria-label="delete"
-                >
-                  <DeleteIcon />
-                </IconButton>
-              </Tooltip>
-            </Toolbar>
-          </Grid>
-          <Grid item key="description">
-            <Typography
-              variant="body2"
-              color="textSecondary"
-              gutterBottom={false}
-              sx={{ fontSize: '13px' }}
-            >
-              {systems[systemIndex].description}
-            </Typography>
-          </Grid>
-        </Grid>
-      </CardContent>
-      <Divider variant="middle" />
-      <SystemCardInstances
-        instances={systems[systemIndex].instances}
-        fileHeader={`${systems[systemIndex].name}[${systems[systemIndex].version}]`}
-      />
-    </Card>
+      </Card>
+      {alert && <Snackbar status={alert} />}
+    </>
   )
 }
 

--- a/src/pages/SystemIndex/SystemIndex.test.tsx
+++ b/src/pages/SystemIndex/SystemIndex.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { mockAxios } from 'test/axios-mock'
+import { TSystem } from 'test/test-values'
+import { AllProviders } from 'test/testMocks'
+
+import { SystemsIndex } from './SystemIndex'
+
+describe('SystemIndex', () => {
+  test('renders SystemIndex page with contents', async () => {
+    render(
+      <AllProviders>
+        <SystemsIndex />
+      </AllProviders>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Systems')).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('table')).toBeInTheDocument()
+    const table = screen.getByRole('table')
+
+    const rows = within(table).getAllByRole('row')
+    expect(rows.length).toEqual(2)
+
+    const headerRow = rows[0]
+    expect(within(headerRow).getByText('Namespace')).toBeInTheDocument()
+    expect(within(headerRow).getByText('System')).toBeInTheDocument()
+    expect(within(headerRow).getByText('Version')).toBeInTheDocument()
+    expect(within(headerRow).getByText('Description')).toBeInTheDocument()
+    expect(within(headerRow).getByText('Commands')).toBeInTheDocument()
+    expect(within(headerRow).getByText('Instances')).toBeInTheDocument()
+
+    const dataRow = rows[1]
+    expect(within(dataRow).getByText('test')).toBeInTheDocument()
+    expect(within(dataRow).getByText('testSystem')).toBeInTheDocument()
+    expect(within(dataRow).getByText('1.0.0')).toBeInTheDocument()
+    expect(within(dataRow).getByText('testing a system')).toBeInTheDocument()
+    const oneCells = within(dataRow).getAllByText(1)
+    expect(oneCells.length).toEqual(2)
+    expect(within(dataRow).getByText('Explore')).toBeInTheDocument()
+  })
+
+  test('Alert is shown on error from getSystems()', async () => {
+    mockAxios.onGet('/api/v1/systems').reply(404)
+
+    render(
+      <AllProviders>
+        <SystemsIndex />
+      </AllProviders>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Systems')).toBeInTheDocument()
+    })
+
+    const errorMessage = 'ERROR: Error: Request failed with status code 404'
+    expect(screen.getByText(errorMessage)).toBeInTheDocument()
+
+    mockAxios.onGet('/api/v1/systems').reply(200, [TSystem])
+  })
+})

--- a/src/pages/SystemIndex/SystemIndex.tsx
+++ b/src/pages/SystemIndex/SystemIndex.tsx
@@ -1,23 +1,50 @@
 import { Box } from '@mui/material'
 import { Divider } from 'components/Divider'
 import { PageHeader } from 'components/PageHeader'
+import { Snackbar } from 'components/Snackbar'
 import { Table } from 'components/Table'
+import { useSystems } from 'hooks/useSystems'
 import {
   useSystemIndexTableColumns,
   useSystemIndexTableData,
 } from 'pages/SystemIndex'
+import { useEffect, useState } from 'react'
+import { System } from 'types/backend-types'
+import { SnackbarState } from 'types/custom-types'
 
 const SystemsIndex = () => {
+  const [systems, setSystems] = useState<System[]>([])
+  const [alert, setAlert] = useState<SnackbarState | undefined>(undefined)
+  const { getSystems } = useSystems()
+
+  useEffect(() => {
+    getSystems()
+      .then((response) => {
+        setSystems(response.data)
+      })
+      .catch((e) => {
+        setAlert({
+          severity: 'error',
+          message: e,
+          doNotAutoDismiss: true,
+        })
+      })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   return (
-    <Box>
-      <PageHeader title="Systems" description="" />
-      <Divider />
-      <Table
-        tableKey="Systems"
-        data={useSystemIndexTableData()}
-        columns={useSystemIndexTableColumns()}
-      />
-    </Box>
+    <>
+      <Box>
+        <PageHeader title="Systems" description="" />
+        <Divider />
+        <Table
+          tableKey="Systems"
+          data={useSystemIndexTableData(systems)}
+          columns={useSystemIndexTableColumns()}
+        />
+      </Box>
+      {alert && <Snackbar status={alert} />}
+    </>
   )
 }
 

--- a/src/pages/SystemIndex/systemIndexHelpers.tsx
+++ b/src/pages/SystemIndex/systemIndexHelpers.tsx
@@ -1,5 +1,4 @@
 import { DefaultCellRenderer } from 'components/Table/defaults'
-import { useSystems } from 'hooks/useSystems'
 import { ExploreButton } from 'pages/SystemIndex'
 import { useMemo } from 'react'
 import { Column } from 'react-table'
@@ -27,10 +26,8 @@ const systemMapper = (system: System): SystemIndexTableData => {
   }
 }
 
-const useSystemIndexTableData = (): SystemIndexTableData[] => {
-  const systemClient = useSystems()
-  const systemList = systemClient.systems
-  return systemList.map(systemMapper)
+const useSystemIndexTableData = (systems: System[]): SystemIndexTableData[] => {
+  return systems.map(systemMapper)
 }
 
 const useSystemIndexTableColumns = () => {

--- a/src/test/axios-mock.ts
+++ b/src/test/axios-mock.ts
@@ -58,10 +58,12 @@ mock
     }
     return [200, Object.assign({}, mockData.TJob, { status: 'PAUSED' })]
   })
+  mock.onPatch('/api/v1/systems/testsys').reply(200, '')
 
 // Success DELETE
 mock.onDelete(regexUsers).reply(204, '')
 mock.onDelete(`/api/v1/jobs/${mockData.TJob.id}`).reply(204, '')
+mock.onDelete('/api/v1/systems/testsys').reply(204)
 
 // default
 mock.onAny().reply(200, 'undefined axios mock - add to axios-mock.ts')


### PR DESCRIPTION
Closes #197 

- Refactored and added tests for the useSystems hook
- Refactored pages that used the old useSystems hook: NamespaceCard, SystemIndex, SystemAdminCard, UpdateJobView, JobCreateSystemsTable
- Added tests for NamespaceCard and SystemIndex
- Snackbar alerts in respective component when useSystems hook fails