### PR TITLE
#202 - Routes user to url path entered after login

### DIFF
--- a/src/components/Routes/Routes.tsx
+++ b/src/components/Routes/Routes.tsx
@@ -27,8 +27,9 @@ const UsersView = lazy(() => import('pages/UsersView'))
 
 const Routes = () => {
   const { authEnabled } = ServerConfigContainer.useContainer()
-  const { hasPermission } = PermissionsContainer.useContainer()
 
+  const { hasPermission, isPermissionsSet } =
+    PermissionsContainer.useContainer()
   if (authEnabled === undefined) return null
 
   return (
@@ -84,14 +85,18 @@ const Routes = () => {
         </Route>
       )}
       {authEnabled && <Route path="/login" element={<Login />} />}
-      <Route
-        path="*"
-        element={
-          <RequireAuth>
-            <Navigate replace to="/systems" />
-          </RequireAuth>
-        }
-      />
+      {isPermissionsSet === authEnabled || isPermissionsSet ? (
+        <Route
+          path="*"
+          element={
+            <RequireAuth>
+              <Navigate replace to="/systems" />
+            </RequireAuth>
+          }
+        />
+      ) : (
+        <Route path="*" element={<RequireAuth />} />
+      )}
     </ReactRouterDomRoutes>
   )
 }

--- a/src/components/Routes/Routes.tsx
+++ b/src/components/Routes/Routes.tsx
@@ -85,7 +85,7 @@ const Routes = () => {
         </Route>
       )}
       {authEnabled && <Route path="/login" element={<Login />} />}
-      {isPermissionsSet === authEnabled || isPermissionsSet ? (
+      {isPermissionsSet() === authEnabled || isPermissionsSet() ? (
         <Route
           path="*"
           element={

--- a/src/containers/AuthContainer.tsx
+++ b/src/containers/AuthContainer.tsx
@@ -3,7 +3,7 @@ import { SocketContainer } from 'containers/SocketContainer'
 import { useMyAxios } from 'hooks/useMyAxios'
 import { TokenResponse, useToken } from 'hooks/useToken'
 import { useCallback, useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import Cookies from 'universal-cookie'
 import { createContainer } from 'unstated-next'
 
@@ -62,11 +62,12 @@ const useAuth = () => {
     )
   }, [clearToken, isAuthenticated, onTokenRefreshRequired, setUser])
 
+  const { pathname } = useLocation()
   const logout = useCallback(() => {
     clearToken()
     setUser(null)
-    navigate('/login')
-  }, [clearToken, setUser, navigate])
+    navigate(pathname)
+  }, [clearToken, setUser, navigate, pathname])
 
   const login = useCallback(
     async (username: string, password: string) => {

--- a/src/containers/PermissionsContainer.test.tsx
+++ b/src/containers/PermissionsContainer.test.tsx
@@ -34,8 +34,8 @@ describe('Permissions Container', () => {
     })
     expect(consoleSpy).toHaveBeenCalledWith('Setting user perms', undefined)
     expect(consoleSpy).toHaveBeenCalledWith('authEnabled', false)
-    expect(consoleSpy).toHaveBeenCalledWith('globalPerms', [])
-    expect(consoleSpy).toHaveBeenCalledWith('domainPerms', {})
+    expect(consoleSpy).toHaveBeenCalledWith('globalPerms', undefined)
+    expect(consoleSpy).toHaveBeenCalledWith('domainPerms', undefined)
   })
 
   test('no logs if disabled', async () => {

--- a/src/containers/PermissionsContainer.tsx
+++ b/src/containers/PermissionsContainer.tsx
@@ -14,6 +14,9 @@ const usePermissions = () => {
   const { DEBUG_PERMISSION } = DebugContainer.useContainer()
   const { authEnabled } = ServerConfigContainer.useContainer()
   const { user, tokenExpiration } = AuthContainer.useContainer()
+  const [isPermissionsSet, setIsPermissionsSet] = useState<boolean>(
+    cookies.get('isPermissionsSet'),
+  )
   const [globalPerms, setGlobalPerms] = useState<string[]>(
     cookies.get('globalPerms'),
   )
@@ -28,8 +31,10 @@ const usePermissions = () => {
   const resetPerms = () => {
     cookies.remove('globalPerms', { path: '/' })
     cookies.remove('domainPerms', { path: '/' })
+    cookies.remove('isPermissionsSet', { path: '/' })
     setGlobalPerms([])
     setDomainPerms({})
+    setIsPermissionsSet(false)
   }
 
   const getUserObj = useCallback(() => {
@@ -50,6 +55,11 @@ const usePermissions = () => {
           { path: '/', expires: tokenExpiration },
         )
         setDomainPerms(response.data.permissions.domain_permissions)
+        cookies.set('isPermissionsSet', true, {
+          path: '/',
+          expires: tokenExpiration,
+        })
+        setIsPermissionsSet(true)
       })
     } else {
       resetPerms()
@@ -163,6 +173,7 @@ const usePermissions = () => {
     hasGardenPermission,
     hasSystemPermission,
     hasJobPermission,
+    isPermissionsSet,
   }
 }
 

--- a/src/containers/PermissionsContainer.tsx
+++ b/src/containers/PermissionsContainer.tsx
@@ -14,15 +14,15 @@ const usePermissions = () => {
   const { DEBUG_PERMISSION } = DebugContainer.useContainer()
   const { authEnabled } = ServerConfigContainer.useContainer()
   const { user, tokenExpiration } = AuthContainer.useContainer()
-  const [isPermissionsSet, setIsPermissionsSet] = useState<boolean>(
-    cookies.get('isPermissionsSet'),
-  )
-  const [globalPerms, setGlobalPerms] = useState<string[]>(
+  const [globalPerms, setGlobalPerms] = useState<string[] | undefined>(
     cookies.get('globalPerms'),
   )
-  const [domainPerms, setDomainPerms] = useState<{
-    [key: string]: DomainPermission
-  }>(cookies.get('domainPerms'))
+  const [domainPerms, setDomainPerms] = useState<
+    | {
+        [key: string]: DomainPermission
+      }
+    | undefined
+  >(cookies.get('domainPerms'))
 
   const { getGarden } = useGardens()
   const { getSystems } = useSystems()
@@ -31,10 +31,12 @@ const usePermissions = () => {
   const resetPerms = () => {
     cookies.remove('globalPerms', { path: '/' })
     cookies.remove('domainPerms', { path: '/' })
-    cookies.remove('isPermissionsSet', { path: '/' })
-    setGlobalPerms([])
-    setDomainPerms({})
-    setIsPermissionsSet(false)
+    setGlobalPerms(undefined)
+    setDomainPerms(undefined)
+  }
+
+  const isPermissionsSet = (): boolean => {
+    return globalPerms !== undefined && domainPerms !== undefined
   }
 
   const getUserObj = useCallback(() => {
@@ -55,11 +57,6 @@ const usePermissions = () => {
           { path: '/', expires: tokenExpiration },
         )
         setDomainPerms(response.data.permissions.domain_permissions)
-        cookies.set('isPermissionsSet', true, {
-          path: '/',
-          expires: tokenExpiration,
-        })
-        setIsPermissionsSet(true)
       })
     } else {
       resetPerms()
@@ -99,9 +96,9 @@ const usePermissions = () => {
       return !!baseCheck
     }
     return (
-      globalPerms.includes(permission) ||
+      globalPerms?.includes(permission) ||
       // eslint-disable-next-line no-prototype-builtins
-      !!domainPerms.hasOwnProperty(permission)
+      !!domainPerms?.hasOwnProperty(permission)
     )
   }
 
@@ -110,11 +107,11 @@ const usePermissions = () => {
     if (typeof baseCheck !== 'undefined') {
       return !!baseCheck
     }
-    if (globalPerms.includes(permission)) {
+    if (globalPerms?.includes(permission)) {
       return true
     }
     // eslint-disable-next-line no-prototype-builtins
-    if (garden.id && domainPerms.hasOwnProperty(permission)) {
+    if (garden.id && domainPerms?.hasOwnProperty(permission)) {
       return domainPerms[permission].garden_ids.includes(garden.id)
     }
     return false
@@ -129,7 +126,7 @@ const usePermissions = () => {
     if (typeof baseCheck !== 'undefined') {
       return !!baseCheck
     }
-    if (globalPerms.includes(permission)) {
+    if (globalPerms?.includes(permission)) {
       return true
     }
     const response = await getGarden(namespace)
@@ -138,7 +135,7 @@ const usePermissions = () => {
       return true
     }
     // eslint-disable-next-line no-prototype-builtins
-    if (domainPerms.hasOwnProperty(permission)) {
+    if (domainPerms?.hasOwnProperty(permission)) {
       return domainPerms[permission].system_ids.includes(systemId)
     }
     return false

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -28,7 +28,7 @@ const Login = () => {
   const navigate = useNavigate()
 
   const from: string =
-    state instanceof Object && 'from' in state ? state['from'] : '/jobs'
+    state instanceof Object && 'from' in state ? state['from'] : '/systems'
   const nextPage = () => {
     navigate(from, { replace: true })
   }


### PR DESCRIPTION
Closes #202 

Changed how the router routes user after login. 

If you navigate to any route other than `/systems` before logging in you should be routed to the route entered instead of being routed to `/systems`, as long as  you have access to that route. If you do not have access to the route you will be routed to `/systems`