### PR TITLE
#218 - Confirm deleting job

### DIFF
--- a/src/pages/JobView/JobView.test.tsx
+++ b/src/pages/JobView/JobView.test.tsx
@@ -195,7 +195,6 @@ describe('JobView', () => {
     })
   })
 
-  // TODO: for some reason these tests are broken
   describe('user has permission', () => {
     beforeAll(() => {
       mockAxios.onGet('/config').reply(200, TServerAuthConfig)
@@ -206,7 +205,7 @@ describe('JobView', () => {
       mockAxios.onGet('/config').reply(200, TServerConfig)
     })
 
-    test.skip('renders Delete button', async () => {
+    test('renders Delete button', async () => {
       render(
         <LoggedInProviders>
           <JobView />
@@ -217,7 +216,7 @@ describe('JobView', () => {
       })
     })
 
-    test.skip('renders Update button', async () => {
+    test('renders Update button', async () => {
       render(
         <LoggedInProviders>
           <JobView />
@@ -228,7 +227,7 @@ describe('JobView', () => {
       })
     })
 
-    test.skip('renders Run button', async () => {
+    test('renders Run button', async () => {
       render(
         <LoggedInProviders>
           <JobView />
@@ -250,7 +249,7 @@ describe('JobView', () => {
       })
     })
 
-    test.skip('render Pause button when jobs', async () => {
+    test('render Pause button when jobs', async () => {
       render(
         <LoggedInProviders>
           <JobView />
@@ -330,6 +329,25 @@ describe('JobView', () => {
     fireEvent.click(screen.getAllByRole('button', { name: 'Expand Area' })[0])
     await waitFor(() => {
       expect(screen.queryByText('Request Template')).not.toBeInTheDocument()
+    })
+  })
+
+  test('makes user confirm to delete job', async () => {
+    render(
+      <AllProviders>
+        <JobView />
+      </AllProviders>,
+    )
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Delete job' }),
+      ).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Delete job' }))
+    expect(screen.getByText('Delete Job?')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await waitFor(() => {
+      expect(screen.queryByText('Delete Job?')).not.toBeInTheDocument()
     })
   })
 })

--- a/src/pages/JobView/JobView.tsx
+++ b/src/pages/JobView/JobView.tsx
@@ -46,17 +46,6 @@ const JobView = () => {
 
   const id = params.id as string
 
-  useEffect(() => {
-    if (job) {
-      const fetchPermission = async () => {
-        const permCheck = await hasJobPermission('job:update', job)
-        setPermission(permCheck || false)
-      }
-      fetchPermission()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [job])
-
   const runNow = (reset: boolean) => {
     runAdHoc(id, reset).then(
       () => {
@@ -103,6 +92,9 @@ const JobView = () => {
           } else {
             setDescription(id)
           }
+          hasJobPermission('job:update', response.data).then((permCheck) => {
+            setPermission(permCheck || false)
+          })
         })
         .catch((e) => {
           console.log(e)
@@ -126,17 +118,6 @@ const JobView = () => {
       return url
     }
     return undefined
-  }, [job])
-
-  useEffect(() => {
-    if (job) {
-      const fetchPermission = async () => {
-        const permCheck = await hasJobPermission('job:update', job)
-        setPermission(permCheck || false)
-      }
-      fetchPermission()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [job])
 
   return (

--- a/src/pages/JobView/JobView.tsx
+++ b/src/pages/JobView/JobView.tsx
@@ -26,7 +26,8 @@ const isIntervalTrigger = (triggerType: string) => {
 }
 
 const JobView = () => {
-  const [open, setOpen] = useState<boolean>(false)
+  const [runOpen, setRunOpen] = useState<boolean>(false)
+  const [delOpen, setDeleteOpen] = useState<boolean>(false)
   const [job, setLocalJob] = useState<Job>()
   const [alert, setAlert] = useState<SnackbarState | undefined>(undefined)
   const [description, setDescription] = useState('')
@@ -177,7 +178,7 @@ const JobView = () => {
           <Button
             variant="contained"
             color="error"
-            onClick={deleteCallback}
+            onClick={() => setDeleteOpen(true)}
             aria-label="Delete job"
           >
             Delete Job
@@ -187,7 +188,7 @@ const JobView = () => {
             color="secondary"
             onClick={() => {
               if (isIntervalTrigger(job.trigger_type)) {
-                setOpen(true)
+                setRunOpen(true)
               } else {
                 runNow(false)
               }
@@ -195,48 +196,6 @@ const JobView = () => {
           >
             Run Now
           </Button>
-          <ModalWrapper
-            open={open}
-            header="Reset the Job Interval"
-            onClose={() => {
-              setOpen(false)
-            }}
-            onCancel={() => {
-              setOpen(false)
-            }}
-            onSubmit={() => {
-              runNow(true)
-              setOpen(false)
-            }}
-            customButton={{
-              label: 'Just Run',
-              cb: () => {
-                runNow(false)
-              },
-              color: 'primary',
-            }}
-            styleOverrides={{ size: 'md', top: '-55%' }}
-            content={
-              <>
-                <Typography>
-                  This job has an interval trigger. Choose one of the buttons
-                  below to update when the job should be run again:
-                </Typography>
-                <Typography>
-                  {'Selecting "Submit" updates the next run time of the job ' +
-                    'based on the time right now.'}
-                </Typography>
-                <Typography>
-                  {'Selecting "Just Run" will run the job now but keep the job\'s ' +
-                    'existing next run time.'}
-                </Typography>
-                <Typography>
-                  {'Selecting "Cancel" cancels running the job now and no changes' +
-                    ' will be made to the next run time.'}
-                </Typography>
-              </>
-            }
-          />
         </Stack>
       )}
       <PageHeader title="Job" description={description} />
@@ -309,6 +268,69 @@ const JobView = () => {
           )}
         </Stack>
       </Stack>
+      <ModalWrapper
+        open={runOpen}
+        header="Reset the Job Interval"
+        onClose={() => {
+          setRunOpen(false)
+        }}
+        onCancel={() => {
+          setRunOpen(false)
+        }}
+        onSubmit={() => {
+          runNow(true)
+          setRunOpen(false)
+        }}
+        customButton={{
+          label: 'Just Run',
+          cb: () => {
+            runNow(false)
+          },
+          color: 'primary',
+        }}
+        styleOverrides={{ size: 'md', top: '-55%' }}
+        content={
+          <>
+            <Typography>
+              This job has an interval trigger. Choose one of the buttons below
+              to update when the job should be run again:
+            </Typography>
+            <Typography>
+              {'Selecting "Submit" updates the next run time of the job ' +
+                'based on the time right now.'}
+            </Typography>
+            <Typography>
+              {'Selecting "Just Run" will run the job now but keep the job\'s ' +
+                'existing next run time.'}
+            </Typography>
+            <Typography>
+              {'Selecting "Cancel" cancels running the job now and no changes' +
+                ' will be made to the next run time.'}
+            </Typography>
+          </>
+        }
+      />
+      <ModalWrapper
+        open={delOpen}
+        header="Delete Job?"
+        onClose={() => {
+          setDeleteOpen(false)
+        }}
+        onCancel={() => {
+          setDeleteOpen(false)
+        }}
+        onSubmit={() => {
+          deleteCallback()
+          setDeleteOpen(false)
+        }}
+        styleOverrides={{ size: 'md', top: '-55%' }}
+        content={
+          <Typography>
+            Remove job {job?.name || id} from the system. This action cannot be
+            undone.
+          </Typography>
+        }
+      />
       {alert && <Snackbar status={alert} />}
     </>
   )


### PR DESCRIPTION
Closes #218 

Adds modal to have user confirm they want to delete job on single job page (under Scheduler). Minor refactor of permission check on that page to fix it.