### PR TITLE
#162 - change table keys

### DIFF
--- a/src/pages/CommandIndex/CommandIndex.tsx
+++ b/src/pages/CommandIndex/CommandIndex.tsx
@@ -39,11 +39,16 @@ const CommandIndex = () => {
     .filter((x) => !!x)
     .map((x) => String(x))
 
+  let tableKey = 'Commands'
+  if (version) tableKey = version + tableKey
+  if (systemName) tableKey = systemName + tableKey
+  if (namespace) tableKey = namespace + tableKey
+
   return (
     <Box>
       <PageHeader title="Commands" description="" />
       <Divider />
-      <Table tableKey="Commands" data={commands} columns={columns}>
+      <Table tableKey={tableKey} data={commands} columns={columns}>
         <Box mb={2}>
           <Breadcrumbs breadcrumbs={breadcrumbs} />
           <FormControlLabel

--- a/src/pages/GardenAdminView/GardenAdminView.tsx
+++ b/src/pages/GardenAdminView/GardenAdminView.tsx
@@ -106,7 +106,7 @@ const GardenAdminView = () => {
           <Typography variant="h6">Connected Systems</Typography>
           {garden.status === 'RUNNING' ? (
             <Table
-              tableKey="systems"
+              tableKey={`${gardenName}systems`}
               data={garden.systems.map(systemMapper)}
               columns={systemsColumns}
             />

--- a/src/pages/RequestView/RequestViewTable.tsx
+++ b/src/pages/RequestView/RequestViewTable.tsx
@@ -149,6 +149,7 @@ const RequestViewTable = ({ request }: RequestViewTableProps) => {
     <>
       <Table
         tableName=""
+        tableKey={`${request.id}RequestIndex`}
         data={data}
         columns={columns}
         hideToolbar={true}
@@ -181,7 +182,7 @@ const RequestViewTable = ({ request }: RequestViewTableProps) => {
           </Typography>
           {showChildren ? (
             <Table
-              tableName="Children"
+              tableName={`${request.id}Children`}
               data={childData}
               hideToolbar={true}
               columns={childColumns}


### PR DESCRIPTION
Closes #162 

Adjust table keys to make each use of the tables distinct in the local storage. 

1. From the Systems page, select any of the `Explore` buttons. For example, select the button for "complex".
2. On the resulting Command page, add a filter. For example, add the term `echo` to the command filter.
3. Navigate back to the Systems page and choose a different `Explore` button. For example, choose the button for "deploy". Note that the table on the resulting page does not have the filter applied.
4. Select any of the pages in the breadcrumb navigation. They should also not have the filter applied.