### PR TITLE
#131 - condense table heading space

### DIFF
--- a/src/components/Table/SSRTable.tsx
+++ b/src/components/Table/SSRTable.tsx
@@ -1,13 +1,12 @@
 import { KeyboardArrowUp } from '@mui/icons-material'
 import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight'
 import {
-  Box,
   CircularProgress,
   TableSortLabel,
   Tooltip,
   Typography,
 } from '@mui/material'
-import { ColumnResizeHandle, FilterChipBar, Toolbar } from 'components/Table'
+import { ColumnResizeHandle, Toolbar } from 'components/Table'
 import { defaultColumnValues, DefaultHeader } from 'components/Table/defaults'
 import {
   fuzzyTextFilter,
@@ -273,9 +272,13 @@ const SSRTable = <
     <Typography>Error...</Typography>
   ) : (
     <>
-      <Toolbar name={tableName || ''} instance={instance} />
-      <FilterChipBar<T> instance={instance} />
-      <Box {...childProps}>{props.children}</Box>
+      <Toolbar
+        instance={instance}
+        childProps={childProps}
+        name={tableName}
+      >
+        {props.children}
+      </Toolbar>
       <StyledTable {...tableProps}>
         <TableHead>
           {headerGroups.map((headerGroup) => {

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,17 +1,8 @@
 import { KeyboardArrowUp } from '@mui/icons-material'
 import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight'
-import { Box, Stack, TableSortLabel, Tooltip } from '@mui/material'
-import {
-  ColumnResizeHandle,
-  FilterChipBar,
-  TablePagination,
-  Toolbar,
-} from 'components/Table'
-import {
-  defaultColumnValues,
-  DefaultGlobalFilter,
-  DefaultHeader,
-} from 'components/Table/defaults'
+import { TableSortLabel, Tooltip } from '@mui/material'
+import { ColumnResizeHandle, TablePagination, Toolbar } from 'components/Table'
+import { defaultColumnValues, DefaultHeader } from 'components/Table/defaults'
 import {
   fuzzyTextFilter,
   InlineFilter,
@@ -92,7 +83,8 @@ const hooks = [
   useRowSelect,
 ]
 
-interface TableProps<T extends ObjectWithStringKeys> extends TableOptions<T> {
+export interface TableProps<T extends ObjectWithStringKeys>
+  extends TableOptions<T> {
   data: T[]
   columns: Column<T>[]
   setSelection?: Dispatch<SetStateAction<T[]>>
@@ -158,8 +150,6 @@ const Table = <T extends ObjectWithStringKeys>(
     prepareRow,
     state,
     selectedFlatRows,
-    setGlobalFilter,
-    preGlobalFilteredRows,
   } = instance
 
   const debouncedState = useDebounce(state, 500)
@@ -206,21 +196,15 @@ const Table = <T extends ObjectWithStringKeys>(
 
   return (
     <>
-      {!hideToolbar && <Toolbar name={tableName || ''} instance={instance} />}
-      <FilterChipBar<T> instance={instance} />
-      {(showGlobalFilter || props.children) && (
-        <Box {...childProps}>
-          <Stack direction="row" spacing={3}>
-            {showGlobalFilter && (
-              <DefaultGlobalFilter<T>
-                preGlobalFilteredRows={preGlobalFilteredRows}
-                globalFilter={state.globalFilter}
-                setGlobalFilter={setGlobalFilter}
-              />
-            )}
-            {props.children}
-          </Stack>
-        </Box>
+      {!hideToolbar && (
+        <Toolbar
+          instance={instance}
+          childProps={childProps}
+          name={tableName}
+          showGlobalFilter={showGlobalFilter}
+        >
+          {props.children}
+        </Toolbar>
       )}
       <StyledTable {...tableProps}>
         <TableHead>

--- a/src/components/Table/toolbar/Toolbar.tsx
+++ b/src/components/Table/toolbar/Toolbar.tsx
@@ -1,17 +1,13 @@
 import ViewColumnIcon from '@mui/icons-material/ViewColumn'
-import {
-  Box,
-  Divider,
-  IconButton,
-  Toolbar as MuiToolbar,
-  Tooltip,
-  Typography,
-} from '@mui/material'
+import { Box, IconButton, Stack, Tooltip, Typography } from '@mui/material'
+import { FilterChipBar } from 'components/Table'
+import { DefaultGlobalFilter } from 'components/Table/defaults'
 import { ColumnHidePage } from 'components/Table/toolbar/ColumnHidePage'
 import {
   MouseEvent as ReactMouseEvent,
   MouseEventHandler,
   ReactElement,
+  ReactNode,
   useCallback,
   useState,
 } from 'react'
@@ -19,8 +15,11 @@ import { ColumnInstance, TableInstance } from 'react-table'
 import { ObjectWithStringKeys } from 'types/custom-types'
 
 interface ToolbarProps<T extends ObjectWithStringKeys> {
-  name: string
+  name?: string
   instance: TableInstance<T>
+  showGlobalFilter?: boolean
+  children: ReactNode
+  childProps: ObjectWithStringKeys
 }
 
 type ActionButtonProps = {
@@ -48,9 +47,6 @@ const SmallIconActionButton = ({
             marginTop: '-6px',
             width: 48,
             height: 48,
-            '&:last-of-type': {
-              marginRight: -12,
-            },
           }}
         >
           {icon}
@@ -82,6 +78,9 @@ const getHideableColumns = <T extends ObjectWithStringKeys>(
 const Toolbar = <T extends ObjectWithStringKeys>({
   name,
   instance,
+  showGlobalFilter,
+  children,
+  childProps,
 }: ToolbarProps<T>) => {
   const { columns } = instance
   const [anchorEl, setAnchorEl] = useState<Element | undefined>(undefined)
@@ -103,27 +102,38 @@ const Toolbar = <T extends ObjectWithStringKeys>({
 
   return (
     <>
-      <MuiToolbar sx={{ display: 'flex', justifyContent: 'space-between' }}>
-        <Box ml={-3}>
-          <Typography variant="h4">{name}</Typography>
-        </Box>
-        <Box>
-          <ColumnHidePage
-            instance={instance}
-            onClose={handleClose}
-            show={columnsOpen}
-            anchorEl={anchorEl}
-          />
-          {hideableColumns.length > 1 && (
-            <SmallIconActionButton
-              icon={<ViewColumnIcon />}
-              onClick={handleColumnsClick}
-              label="Show / hide columns"
+      {name && <Typography variant="h4">{name}</Typography>}
+      <FilterChipBar<T> instance={instance} />
+      <Box
+        {...childProps}
+        display="flex"
+        justifyContent="space-between"
+        alignItems="center"
+      >
+        <Stack direction="row" spacing={3}>
+          {showGlobalFilter && (
+            <DefaultGlobalFilter<T>
+              preGlobalFilteredRows={instance.preGlobalFilteredRows}
+              globalFilter={instance.state.globalFilter}
+              setGlobalFilter={instance.setGlobalFilter}
             />
           )}
-        </Box>
-      </MuiToolbar>
-      <Divider />
+          {children}
+        </Stack>
+        {hideableColumns.length > 1 && (
+          <SmallIconActionButton
+            icon={<ViewColumnIcon />}
+            onClick={handleColumnsClick}
+            label="Show / hide columns"
+          />
+        )}
+      </Box>
+      <ColumnHidePage
+        instance={instance}
+        onClose={handleClose}
+        show={columnsOpen}
+        anchorEl={anchorEl}
+      />
     </>
   )
 }

--- a/src/pages/RequestView/RequestViewTable.tsx
+++ b/src/pages/RequestView/RequestViewTable.tsx
@@ -148,7 +148,6 @@ const RequestViewTable = ({ request }: RequestViewTableProps) => {
   return (
     <>
       <Table
-        tableName=""
         tableKey={`${request.id}RequestIndex`}
         data={data}
         columns={columns}


### PR DESCRIPTION
Closes #131 

Refactor to reduce the amount of empty whitespace above tables. Applied to both table components.