### PR TITLE
161 - fix table rows per page

### DIFF
--- a/src/utils/table-helpers.ts
+++ b/src/utils/table-helpers.ts
@@ -9,6 +9,8 @@ export const getRowPageOptions = (
   maxRows: number,
   totalRows: number,
 ): (number | { value: number; label: string })[] => {
+  if (!totalRows) return []
+
   const optionList: (number | { value: number; label: string })[] = []
   let i = 5
   for (i; i <= maxRows; i += 5) {


### PR DESCRIPTION
Closes #161  
Found the issue in the TablePagination component, specifically where the component resets the pageSize using the getRowPageOptions helper. When first rendered, the table is still waiting on data, but the pageSize is reset anyways. This fix should only reset the pageSize of a table when data is present.

There's also an issue with the SSRTablePagination that keeps resetting the pageSize to 10. Ticket for that is #257  

To test:
* Open the systems index page, or any page that uses the Table component
* Change the Rows per Page
* Either refresh the page or go to a different page and back to the Systems Index page
* The page size should have persisted so that it is the value you selected in bullet 2 