### PR TITLE
#147 - Added Alert to show more info with errors

### DIFF
--- a/src/components/ErrorAlert.test.tsx
+++ b/src/components/ErrorAlert.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { AllProviders } from 'test/testMocks'
 
-import { ErrorAlert, errorMap } from './ErrorAlert'
+import {
+  ErrorAlert,
+  errorMap,
+  ErrorStatusCode,
+  SpecificErrorType,
+} from './ErrorAlert'
 
 describe('ErrorAlert', () => {
   const errorMsg = 'my error message'
@@ -15,7 +20,9 @@ describe('ErrorAlert', () => {
             <ErrorAlert
               statusCode={statusCode}
               errorMsg={errorMsg}
-              specific={specific}
+              specific={
+                specific as 'request' | 'job' | 'garden' | 'user' | undefined
+              }
             />
           </AllProviders>,
         )
@@ -26,15 +33,17 @@ describe('ErrorAlert', () => {
         })
         expect(
           screen.getByText(
-            `Problem: ${errorMap[statusCode]['common'][0].problem}`,
+            `Problem: ${
+              errorMap[statusCode as ErrorStatusCode]['common'][0].problem
+            }`,
           ),
         ).toBeInTheDocument()
-        if (specific) {
+        const specificList =
+          errorMap[statusCode as ErrorStatusCode][specific as SpecificErrorType]
+        if (specificList) {
           // eslint-disable-next-line jest/no-conditional-expect
           expect(
-            screen.getByText(
-              `Problem: ${errorMap[statusCode][specific][0].problem}`,
-            ),
+            screen.getByText(`Problem: ${specificList[0].problem}`),
           ).toBeInTheDocument()
         }
       })

--- a/src/components/ErrorAlert.test.tsx
+++ b/src/components/ErrorAlert.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { AllProviders } from 'test/testMocks'
+
+import { ErrorAlert, errorMap } from './ErrorAlert'
+
+describe('ErrorAlert', () => {
+  const errorMsg = 'my error message'
+  for (const statusCode of [403, 404, 500]) {
+    for (const specific of statusCode === 404
+      ? [undefined, 'request', 'job', 'garden', 'user']
+      : [undefined]) {
+      test(`renders alert with status code ${statusCode} and specific ${specific}`, async () => {
+        render(
+          <AllProviders>
+            <ErrorAlert
+              statusCode={statusCode}
+              errorMsg={errorMsg}
+              specific={specific}
+            />
+          </AllProviders>,
+        )
+        await waitFor(() => {
+          expect(
+            screen.getByText(`Error: ${statusCode} ${errorMsg}`),
+          ).toBeInTheDocument()
+        })
+        expect(
+          screen.getByText(
+            `Problem: ${errorMap[statusCode]['common'][0].problem}`,
+          ),
+        ).toBeInTheDocument()
+        if (specific) {
+          // eslint-disable-next-line jest/no-conditional-expect
+          expect(
+            screen.getByText(
+              `Problem: ${errorMap[statusCode][specific][0].problem}`,
+            ),
+          ).toBeInTheDocument()
+        }
+      })
+    }
+  }
+})

--- a/src/components/ErrorAlert.tsx
+++ b/src/components/ErrorAlert.tsx
@@ -1,7 +1,7 @@
 import {
   Alert,
+  Box,
   Card,
-  CardActions,
   CardContent,
   CardHeader,
   Divider,
@@ -9,8 +9,14 @@ import {
 } from '@mui/material'
 import { Link as RouterLink } from 'react-router-dom'
 
+export type SpecificErrorType = 'request' | 'job' | 'garden' | 'user'
+export type ErrorStatusCode = 403 | 404 | 500
+type ErrorType = { common: AxiosErrorProblem[] } & {
+  [S in SpecificErrorType]?: AxiosErrorProblem[]
+}
+
 interface ErrorAlertProps {
-  specific?: string
+  specific?: SpecificErrorType
   statusCode: number
   errorMsg: string
 }
@@ -21,9 +27,7 @@ type AxiosErrorProblem = {
   resolution: JSX.Element | string
 }
 
-const errorMap: {
-  [key: number]: { [key: string]: AxiosErrorProblem[] }
-} = {
+const errorMap: { [E in ErrorStatusCode]: ErrorType } = {
   403: {
     common: [
       {
@@ -59,10 +63,10 @@ const errorMap: {
           'Beer Garden can be set to remove requests after several ' +
           'minutes, so this request may have been removed.',
         resolution: (
-          <div>
+          <Box>
             Go back to the list of all{' '}
             <RouterLink to="/requests">requests</RouterLink>.
-          </div>
+          </Box>
         ),
       },
     ],
@@ -71,9 +75,9 @@ const errorMap: {
         problem: 'Job was removed',
         description: 'An authorized user could have deleted the job.',
         resolution: (
-          <div>
+          <Box>
             Go back to the list of <RouterLink to="/jobs">jobs</RouterLink>.
-          </div>
+          </Box>
         ),
       },
     ],
@@ -82,10 +86,10 @@ const errorMap: {
         problem: 'Garden was removed',
         description: 'An authorized user could have deleted the garden.',
         resolution: (
-          <div>
+          <Box>
             Go back to the list of{' '}
             <RouterLink to="/admin/gardens">gardens</RouterLink>.
-          </div>
+          </Box>
         ),
       },
     ],
@@ -94,10 +98,10 @@ const errorMap: {
         problem: 'User was removed',
         description: 'An authorized user could have deleted the user.',
         resolution: (
-          <div>
+          <Box>
             Go back to the list of{' '}
             <RouterLink to="/admin/users">users</RouterLink>.
-          </div>
+          </Box>
         ),
       },
     ],
@@ -116,9 +120,12 @@ const errorMap: {
 }
 
 const ErrorAlert = ({ specific, statusCode, errorMsg }: ErrorAlertProps) => {
-  let problemList = errorMap[statusCode]['common']
-  if (specific && errorMap[statusCode][specific]) {
-    problemList = problemList.concat(errorMap[statusCode][specific])
+  const problems = errorMap[statusCode as ErrorStatusCode]
+  let problemList: AxiosErrorProblem[] = []
+  if (problems) {
+    problemList = problems['common'].concat(
+      (specific && problems[specific]) || [],
+    )
   }
 
   return (
@@ -134,7 +141,7 @@ const ErrorAlert = ({ specific, statusCode, errorMsg }: ErrorAlertProps) => {
           <Divider />
           <CardContent>{problem.description}</CardContent>
           <Divider />
-          <CardActions>{problem.resolution}</CardActions>
+          <CardContent>{problem.resolution}</CardContent>
         </Card>
       ))}
     </>

--- a/src/components/ErrorAlert.tsx
+++ b/src/components/ErrorAlert.tsx
@@ -1,0 +1,144 @@
+import {
+  Alert,
+  Card,
+  CardActions,
+  CardContent,
+  CardHeader,
+  Divider,
+  Typography,
+} from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
+
+interface ErrorAlertProps {
+  specific?: string
+  statusCode: number
+  errorMsg: string
+}
+
+type AxiosErrorProblem = {
+  problem: string
+  description: string
+  resolution: JSX.Element | string
+}
+
+const errorMap: {
+  [key: number]: { [key: string]: AxiosErrorProblem[] }
+} = {
+  403: {
+    common: [
+      {
+        problem: 'Insufficient Permissions',
+        description:
+          'You do not have the necessary permission to view this data or perform this action.',
+        resolution:
+          'Contact your administrator and request to be given permission.',
+      },
+      {
+        problem: 'Signature verification failed',
+        description:
+          'The signature of the token used in the request could not be validated by the server.',
+        resolution:
+          'Log out (if currently logged in) and log in again to generate a new token.',
+      },
+    ],
+  },
+  404: {
+    common: [
+      {
+        problem: 'Wrong identifier',
+        description:
+          'The identifiers for the resource may be off. For example, a bookmark may be for an old version' +
+          ' that has been removed.',
+        resolution: 'Double-check that all identifiers are correct',
+      },
+    ],
+    request: [
+      {
+        problem: 'Request was removed',
+        description:
+          'Beer Garden can be set to remove requests after several ' +
+          'minutes, so this request may have been removed.',
+        resolution: (
+          <div>
+            Go back to the list of all{' '}
+            <RouterLink to="/requests">requests</RouterLink>.
+          </div>
+        ),
+      },
+    ],
+    job: [
+      {
+        problem: 'Job was removed',
+        description: 'An authorized user could have deleted the job.',
+        resolution: (
+          <div>
+            Go back to the list of <RouterLink to="/jobs">jobs</RouterLink>.
+          </div>
+        ),
+      },
+    ],
+    garden: [
+      {
+        problem: 'Garden was removed',
+        description: 'An authorized user could have deleted the garden.',
+        resolution: (
+          <div>
+            Go back to the list of{' '}
+            <RouterLink to="/admin/gardens">gardens</RouterLink>.
+          </div>
+        ),
+      },
+    ],
+    user: [
+      {
+        problem: 'User was removed',
+        description: 'An authorized user could have deleted the user.',
+        resolution: (
+          <div>
+            Go back to the list of{' '}
+            <RouterLink to="/admin/users">users</RouterLink>.
+          </div>
+        ),
+      },
+    ],
+  },
+  500: {
+    common: [
+      {
+        problem: 'Unable to route request',
+        description:
+          'The request could not be sent to Beer Garden. Beer Garden may be offline or is unreachable.',
+        resolution:
+          'Contact your system administrator to resolve the issue, or try again at a later time.',
+      },
+    ],
+  },
+}
+
+const ErrorAlert = ({ specific, statusCode, errorMsg }: ErrorAlertProps) => {
+  let problemList = errorMap[statusCode]['common']
+  if (specific && errorMap[statusCode][specific]) {
+    problemList = problemList.concat(errorMap[statusCode][specific])
+  }
+
+  return (
+    <>
+      <Alert severity="error">
+        <Typography variant="h5" color="inherit">
+          Error: {statusCode} {errorMsg}
+        </Typography>
+      </Alert>
+      {problemList.map((problem, index) => (
+        <Card key={`problem${index}`} sx={{ mt: 1 }}>
+          <CardHeader title={`Problem: ${problem.problem}`} />
+          <Divider />
+          <CardContent>{problem.description}</CardContent>
+          <Divider />
+          <CardActions>{problem.resolution}</CardActions>
+        </Card>
+      ))}
+    </>
+  )
+}
+
+export { ErrorAlert, errorMap }

--- a/src/hooks/useBlockList.tsx
+++ b/src/hooks/useBlockList.tsx
@@ -70,7 +70,7 @@ const useBlockList = () => {
     return blockList
   }
 
-  return { blockList, deleteBlockList, addBlockList }
+  return { blockList, error, deleteBlockList, addBlockList }
 }
 
 export { useBlockList }

--- a/src/hooks/useCommands.tsx
+++ b/src/hooks/useCommands.tsx
@@ -182,6 +182,7 @@ const useCommands = () => {
     version,
     includeHidden,
     hiddenOnChange,
+    error,
   }
 }
 

--- a/src/hooks/useCommandsParameterized.tsx
+++ b/src/hooks/useCommandsParameterized.tsx
@@ -1,3 +1,4 @@
+import { AxiosError } from 'axios'
 import { useSystems } from 'hooks/useSystems'
 import {
   ChangeEvent as ReactChangeEvent,
@@ -20,21 +21,32 @@ const useCommandsParameterized = <T,>(formatter: CommandFormatter<T>) => {
   const [commands, setCommands] = useState<T[]>([])
   const [systemId, setSystemId] = useState('')
   const [includeHidden, setIncludeHidden] = useState(false)
+  const [error, setError] = useState<AxiosError>()
   const { namespace, systemName, version } = useParams() as ReturnType<
     typeof useParams
   > & { namespace: string; systemName: string; version: string }
   const { getSystems } = useSystems()
 
   useEffect(() => {
-    getSystems().then((response) => {
-      setCommands(
-        formatter(response.data, includeHidden, namespace, systemName, version),
-      )
-      const foundSystem = response.data.find(
-        (system: System) => system.name === systemName,
-      )
-      if (foundSystem) setSystemId(foundSystem.id)
-    })
+    getSystems()
+      .then((response) => {
+        setCommands(
+          formatter(
+            response.data,
+            includeHidden,
+            namespace,
+            systemName,
+            version,
+          ),
+        )
+        const foundSystem = response.data.find(
+          (system: System) => system.name === systemName,
+        )
+        if (foundSystem) setSystemId(foundSystem.id)
+      })
+      .catch((e) => {
+        setError(e)
+      })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [namespace, version, systemName, includeHidden])
 
@@ -53,6 +65,7 @@ const useCommandsParameterized = <T,>(formatter: CommandFormatter<T>) => {
     version,
     includeHidden,
     hiddenOnChange,
+    error,
   }
 }
 

--- a/src/hooks/useNamespace.tsx
+++ b/src/hooks/useNamespace.tsx
@@ -1,24 +1,23 @@
+import { AxiosRequestConfig } from 'axios'
 import useAxios from 'axios-hooks'
 import { ServerConfigContainer } from 'containers/ConfigContainer'
-import { useEffect, useState } from 'react'
+
+import { useMyAxios } from './useMyAxios'
 
 const useNamespace = () => {
-  // TODO: convert this to return a function that returns a Promise
   const { authEnabled } = ServerConfigContainer.useContainer()
-  const [namespaces, setNamespaces] = useState<string[]>([])
-  const [{ data: namespaceData, error: namespaceError }] = useAxios({
-    url: '/api/v1/namespaces',
-    method: 'get',
-    withCredentials: authEnabled,
-  })
-
-  useEffect(() => {
-    if (namespaceData && !namespaceError) {
-      setNamespaces(namespaceData)
+  const { axiosManualOptions } = useMyAxios()
+  const [, execute] = useAxios({}, axiosManualOptions)
+  const getNamespaces = () => {
+    const config: AxiosRequestConfig = {
+      url: '/api/v1/namespaces',
+      method: 'get',
+      withCredentials: authEnabled,
     }
-  }, [namespaceData, namespaceError])
 
-  return namespaces
+    return execute(config)
+  }
+  return { getNamespaces }
 }
 
-export default useNamespace
+export { useNamespace }

--- a/src/pages/CommandBlocklistView/CommandBlocklistView.tsx
+++ b/src/pages/CommandBlocklistView/CommandBlocklistView.tsx
@@ -1,7 +1,15 @@
 import AddIcon from '@mui/icons-material/Add'
 import DeleteIcon from '@mui/icons-material/Delete'
-import { Box, Button, IconButton, Tooltip } from '@mui/material'
+import {
+  Backdrop,
+  Box,
+  Button,
+  CircularProgress,
+  IconButton,
+  Tooltip,
+} from '@mui/material'
 import { Divider } from 'components/Divider'
+import { ErrorAlert } from 'components/ErrorAlert'
 import { ModalWrapper } from 'components/ModalWrapper'
 import { PageHeader } from 'components/PageHeader'
 import { Table } from 'components/Table'
@@ -15,7 +23,7 @@ import { CommandIndexTableData } from 'types/custom-types'
 export const CommandBlocklistView = () => {
   const [open, setOpen] = useState(false)
   const [selection, setSelection] = useState<CommandIndexTableData[]>([])
-  const { blockList, deleteBlockList, addBlockList } = useBlockList()
+  const { blockList, error, deleteBlockList, addBlockList } = useBlockList()
   const { commands } = useCommands()
 
   // populate data for modal All Commands list table
@@ -70,7 +78,10 @@ export const CommandBlocklistView = () => {
     })
   }, [blockList, deleteBlockList])
 
-  return (
+  const tableColumns = useTableColumns()
+  const modalColumns = useModalColumns()
+
+  return !error ? (
     <Box>
       <Tooltip title="Add command">
         <Button
@@ -103,7 +114,7 @@ export const CommandBlocklistView = () => {
           <Table
             tableKey="BlocklistAdd"
             data={commandListData}
-            columns={useModalColumns()}
+            columns={modalColumns}
             maxrows={10}
             setSelection={setSelection}
           />
@@ -111,11 +122,16 @@ export const CommandBlocklistView = () => {
       />
       <PageHeader title="Command Publishing Blocklist" description="" />
       <Divider />
-      <Table
-        tableKey="Blocklist"
-        data={blocklistData}
-        columns={useTableColumns()}
-      />
+      <Table tableKey="Blocklist" data={blocklistData} columns={tableColumns} />
     </Box>
+  ) : error.response ? (
+    <ErrorAlert
+      errorMsg={error.response.statusText}
+      statusCode={error.response?.status}
+    />
+  ) : (
+    <Backdrop open={true}>
+      <CircularProgress color="inherit" />
+    </Backdrop>
   )
 }

--- a/src/pages/CommandBlocklistView/CommandBlocklistView.tsx
+++ b/src/pages/CommandBlocklistView/CommandBlocklistView.tsx
@@ -127,7 +127,7 @@ export const CommandBlocklistView = () => {
   ) : error.response ? (
     <ErrorAlert
       errorMsg={error.response.statusText}
-      statusCode={error.response?.status}
+      statusCode={error.response.status}
     />
   ) : (
     <Backdrop open={true}>

--- a/src/pages/CommandIndex/CommandIndex.tsx
+++ b/src/pages/CommandIndex/CommandIndex.tsx
@@ -1,6 +1,13 @@
-import { Box, Checkbox, FormControlLabel } from '@mui/material'
+import {
+  Backdrop,
+  Box,
+  Checkbox,
+  CircularProgress,
+  FormControlLabel,
+} from '@mui/material'
 import Breadcrumbs from 'components/Breadcrumbs'
 import { Divider } from 'components/Divider'
+import { ErrorAlert } from 'components/ErrorAlert'
 import { PageHeader } from 'components/PageHeader'
 import { Table } from 'components/Table'
 import { PermissionsContainer } from 'containers/PermissionsContainer'
@@ -20,6 +27,7 @@ const CommandIndex = () => {
     version,
     includeHidden,
     hiddenOnChange,
+    error,
   } = useCommandsParameterized<CommandIndexTableData>(commandsFromSystems)
   const [permission, setPermission] = useState(false)
 
@@ -46,7 +54,7 @@ const CommandIndex = () => {
   if (systemName) tableKey = systemName + tableKey
   if (namespace) tableKey = namespace + tableKey
 
-  return (
+  return !error ? (
     <Box>
       <PageHeader title="Commands" description="" />
       <Divider />
@@ -66,6 +74,15 @@ const CommandIndex = () => {
         </Box>
       </Table>
     </Box>
+  ) : error.response ? (
+    <ErrorAlert
+      statusCode={error.response?.status}
+      errorMsg={error.response.statusText}
+    />
+  ) : (
+    <Backdrop open={true}>
+      <CircularProgress color="inherit" />
+    </Backdrop>
   )
 }
 

--- a/src/pages/CommandIndex/CommandIndex.tsx
+++ b/src/pages/CommandIndex/CommandIndex.tsx
@@ -76,7 +76,7 @@ const CommandIndex = () => {
     </Box>
   ) : error.response ? (
     <ErrorAlert
-      statusCode={error.response?.status}
+      statusCode={error.response.status}
       errorMsg={error.response.statusText}
     />
   ) : (

--- a/src/pages/GardenAdmin/GardenAdmin.tsx
+++ b/src/pages/GardenAdmin/GardenAdmin.tsx
@@ -1,6 +1,7 @@
-import { Box, Grid } from '@mui/material'
+import { Backdrop, Box, CircularProgress, Grid } from '@mui/material'
 import useAxios from 'axios-hooks'
 import { Divider } from 'components/Divider'
+import { ErrorAlert } from 'components/ErrorAlert'
 import { GardenSyncButton } from 'components/GardenSyncButton'
 import { PageHeader } from 'components/PageHeader'
 import { Snackbar } from 'components/Snackbar'
@@ -49,7 +50,7 @@ const GardensAdmin = (): JSX.Element => {
     }
   }, [addCallback, removeCallback, refetch])
 
-  return (
+  return !error ? (
     <>
       {hasPermission('garden:create') && (
         <CreateGarden setRequestStatus={setRequestStatus} />
@@ -73,6 +74,15 @@ const GardensAdmin = (): JSX.Element => {
       </Grid>
       {requestStatus ? <Snackbar status={requestStatus} /> : null}
     </>
+  ) : error.response ? (
+    <ErrorAlert
+      statusCode={error.response?.status}
+      errorMsg={error.response.statusText}
+    />
+  ) : (
+    <Backdrop open={true}>
+      <CircularProgress color="inherit" />
+    </Backdrop>
   )
 }
 

--- a/src/pages/GardenAdmin/GardenAdmin.tsx
+++ b/src/pages/GardenAdmin/GardenAdmin.tsx
@@ -76,7 +76,7 @@ const GardensAdmin = (): JSX.Element => {
     </>
   ) : error.response ? (
     <ErrorAlert
-      statusCode={error.response?.status}
+      statusCode={error.response.status}
       errorMsg={error.response.statusText}
     />
   ) : (

--- a/src/pages/GardenAdminView/GardenAdminView.tsx
+++ b/src/pages/GardenAdminView/GardenAdminView.tsx
@@ -141,7 +141,7 @@ const GardenAdminView = () => {
   ) : error.response ? (
     <ErrorAlert
       specific="garden"
-      statusCode={error.response?.status}
+      statusCode={error.response.status}
       errorMsg={error.response.statusText}
     />
   ) : (

--- a/src/pages/GardenAdminView/GardenAdminView.tsx
+++ b/src/pages/GardenAdminView/GardenAdminView.tsx
@@ -1,6 +1,7 @@
 import { Alert, Backdrop, CircularProgress, Typography } from '@mui/material'
 import useAxios from 'axios-hooks'
 import { Divider } from 'components/Divider'
+import { ErrorAlert } from 'components/ErrorAlert'
 import { GardenConnectionForm } from 'components/GardenConnectionForm'
 import { GardenSyncButton } from 'components/GardenSyncButton'
 import { PageHeader } from 'components/PageHeader'
@@ -87,7 +88,7 @@ const GardenAdminView = () => {
       })
   }
 
-  return (
+  return !error ? (
     <>
       {hasPermission('garden:update') && (
         <Typography style={{ flex: 1, float: 'right' }}>
@@ -137,6 +138,16 @@ const GardenAdminView = () => {
       )}
       {requestStatus ? <Snackbar status={requestStatus} /> : null}
     </>
+  ) : error.response ? (
+    <ErrorAlert
+      specific="garden"
+      statusCode={error.response?.status}
+      errorMsg={error.response.statusText}
+    />
+  ) : (
+    <Backdrop open={true}>
+      <CircularProgress color="inherit" />
+    </Backdrop>
   )
 }
 

--- a/src/pages/JobCreate/JobCreate.tsx
+++ b/src/pages/JobCreate/JobCreate.tsx
@@ -1,7 +1,9 @@
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import CancelIcon from '@mui/icons-material/Cancel'
-import { Box, Button } from '@mui/material'
+import { Backdrop, Box, Button, CircularProgress } from '@mui/material'
+import { AxiosError } from 'axios'
 import { Divider } from 'components/Divider'
+import { ErrorAlert } from 'components/ErrorAlert'
 import { PageHeader } from 'components/PageHeader'
 import { JobCreateCommandsTable } from 'pages/JobCreate/JobCreateCommandsTable'
 import { JobCreateForwarder } from 'pages/JobCreate/JobCreateForwarder'
@@ -15,6 +17,7 @@ const DEBUG_DISPATCH_FUNCTIONS = false
 const JobCreate = () => {
   const [system, _setSystem] = useState<System | undefined>(undefined)
   const [command, _setCommand] = useState<Command | undefined>(undefined)
+  const [error, setError] = useState<AxiosError>()
   const navigate = useNavigate()
 
   const setSystem = (system: System) => {
@@ -41,11 +44,22 @@ const JobCreate = () => {
     </Button>
   )
 
-  return !system ? (
+  return error ? (
+    error?.response ? (
+      <ErrorAlert
+        statusCode={error.response?.status}
+        errorMsg={error.response.statusText}
+      />
+    ) : (
+      <Backdrop open={true}>
+        <CircularProgress color="inherit" />
+      </Backdrop>
+    )
+  ) : !system ? (
     <Box>
       <PageHeader title="Choose System For Job" description="" />
       <Divider />
-      <JobCreateSystemsTable systemSetter={setSystem}>
+      <JobCreateSystemsTable systemSetter={setSystem} errorSetter={setError}>
         {cancelAllSchedulingButton}
       </JobCreateSystemsTable>
     </Box>

--- a/src/pages/JobCreate/JobCreate.tsx
+++ b/src/pages/JobCreate/JobCreate.tsx
@@ -45,9 +45,9 @@ const JobCreate = () => {
   )
 
   return error ? (
-    error?.response ? (
+    error.response ? (
       <ErrorAlert
-        statusCode={error.response?.status}
+        statusCode={error.response.status}
         errorMsg={error.response.statusText}
       />
     ) : (

--- a/src/pages/JobCreate/JobCreateSystemsTable.tsx
+++ b/src/pages/JobCreate/JobCreateSystemsTable.tsx
@@ -1,4 +1,4 @@
-import { Snackbar } from 'components/Snackbar'
+import { AxiosError } from 'axios'
 import { Table } from 'components/Table'
 import { useSystems } from 'hooks/useSystems'
 import {
@@ -7,17 +7,17 @@ import {
 } from 'pages/JobCreate/JobCreateSystemsData'
 import { PropsWithChildren, useEffect, useState } from 'react'
 import { System } from 'types/backend-types'
-import { SnackbarState } from 'types/custom-types'
 
 interface JobCreateSystemTableProps {
   systemSetter: (system: System) => void
+  errorSetter: (error: AxiosError) => void
 }
 const JobCreateSystemsTable = ({
   systemSetter,
+  errorSetter,
   children,
 }: PropsWithChildren<JobCreateSystemTableProps>) => {
   const [systems, setSystems] = useState<System[]>([])
-  const [alert, setAlert] = useState<SnackbarState | undefined>(undefined)
   const { getSystems } = useSystems()
 
   useEffect(() => {
@@ -26,27 +26,20 @@ const JobCreateSystemsTable = ({
         setSystems(response.data)
       })
       .catch((e) => {
-        setAlert({
-          severity: 'error',
-          message: e,
-          doNotAutoDismiss: true,
-        })
+        errorSetter(e)
       })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return (
-    <>
-      <Table
-        tableKey="JobSystems"
-        data={useSystemsData(systems, systemSetter)}
-        columns={useSystemColumns()}
-        showGlobalFilter
-      >
-        {children}
-      </Table>
-      {alert && <Snackbar status={alert} />}
-    </>
+    <Table
+      tableKey="JobSystems"
+      data={useSystemsData(systems, systemSetter)}
+      columns={useSystemColumns()}
+      showGlobalFilter
+    >
+      {children}
+    </Table>
   )
 }
 

--- a/src/pages/JobIndex/JobIndex.test.tsx
+++ b/src/pages/JobIndex/JobIndex.test.tsx
@@ -29,6 +29,7 @@ function createDtWithFiles(files: File[] = []) {
  * createFile creates a mock File object
  * @param {string} name
  * @param {string[]} contents
+ * @param {string} type
  */
 function createFile(
   name: string,
@@ -90,7 +91,7 @@ describe('JobIndex', () => {
       </AllProviders>,
     )
     await waitFor(() => {
-      expect(screen.getByText('ERROR: Failure to get jobs')).toBeInTheDocument()
+      expect(screen.getByText('Problem: Wrong identifier')).toBeInTheDocument()
     })
     expect(screen.queryByText(TJob.name)).not.toBeInTheDocument()
   })
@@ -137,6 +138,7 @@ describe('JobIndex', () => {
     })
 
     test('cancel dialog', async () => {
+      mockAxios.onGet('/api/v1/jobs').reply(200, [])
       render(
         <LoggedInProviders>
           <JobIndex />
@@ -157,6 +159,7 @@ describe('JobIndex', () => {
     })
 
     test('dialog allows adding files', async () => {
+      mockAxios.onGet('/api/v1/jobs').reply(200, [])
       const files = [createFile('file1', [JSON.stringify([TJob])])]
       const data = createDtWithFiles(files)
       render(
@@ -187,6 +190,7 @@ describe('JobIndex', () => {
     })
 
     test('error on bad file', async () => {
+      mockAxios.onGet('/api/v1/jobs').reply(200, [])
       const files = [createFile('file1', [], 'img/png')]
       const data = createDtWithFiles(files)
       render(

--- a/src/pages/JobIndex/JobIndex.tsx
+++ b/src/pages/JobIndex/JobIndex.tsx
@@ -1,5 +1,7 @@
-import { AlertColor, Button } from '@mui/material'
+import { AlertColor, Backdrop, Button, CircularProgress } from '@mui/material'
+import { AxiosError } from 'axios'
 import { Divider } from 'components/Divider'
+import { ErrorAlert } from 'components/ErrorAlert'
 import { ModalWrapper } from 'components/ModalWrapper'
 import { PageHeader } from 'components/PageHeader'
 import { Snackbar } from 'components/Snackbar'
@@ -25,6 +27,8 @@ const JobIndex = () => {
   const { getJobs, importJobs, exportJobs } = useJobs()
   const navigate = useNavigate()
 
+  const [errorFetch, setErrorFetch] = useState<AxiosError>()
+
   const errorHandler = (e: string) => {
     setAlert({
       severity: 'error',
@@ -39,11 +43,7 @@ const JobIndex = () => {
         setJobs(response.data)
       })
       .catch((e) => {
-        setAlert({
-          severity: 'error',
-          message: e.response?.data.message || e,
-          doNotAutoDismiss: true,
-        })
+        setErrorFetch(e)
       })
   }
 
@@ -117,11 +117,13 @@ const JobIndex = () => {
     })
   }, [jobs])
 
-  return (
+  const jobColumns = useJobColumns()
+
+  return !errorFetch ? (
     <>
       <PageHeader title="Request Scheduler" description="" />
       <Divider />
-      <Table tableKey="JobIndex" data={jobData} columns={useJobColumns()}>
+      <Table tableKey="JobIndex" data={jobData} columns={jobColumns}>
         {hasPermission('job:create') && (
           <Button onClick={createRequestOnClick}>Create</Button>
         )}
@@ -171,6 +173,15 @@ const JobIndex = () => {
       />
       {alert ? <Snackbar status={alert} /> : null}
     </>
+  ) : errorFetch.response ? (
+    <ErrorAlert
+      statusCode={errorFetch.response?.status}
+      errorMsg={errorFetch.response.statusText}
+    />
+  ) : (
+    <Backdrop open={true}>
+      <CircularProgress color="inherit" />
+    </Backdrop>
   )
 }
 

--- a/src/pages/JobView/JobView.test.tsx
+++ b/src/pages/JobView/JobView.test.tsx
@@ -284,7 +284,7 @@ describe('JobView', () => {
       </AllProviders>,
     )
     await waitFor(() => {
-      expect(screen.getByTestId('dataLoading')).toBeInTheDocument()
+      expect(screen.getByTitle('loading circle')).toBeInTheDocument()
     })
     // reset mock
     mockAxios.onGet(`/api/v1/jobs/${TJob.id}`).reply(200, TJob)

--- a/src/pages/JobView/JobView.tsx
+++ b/src/pages/JobView/JobView.tsx
@@ -1,4 +1,5 @@
 import {
+  Backdrop,
   Box,
   Button,
   CircularProgress,
@@ -8,6 +9,7 @@ import {
 } from '@mui/material'
 import { AxiosError, AxiosResponse } from 'axios'
 import { Divider } from 'components/Divider'
+import { ErrorAlert } from 'components/ErrorAlert'
 import { useJobRequestCreation } from 'components/JobRequestCreation'
 import { JsonCard } from 'components/JsonCard'
 import { LabeledData } from 'components/LabeledData'
@@ -47,6 +49,7 @@ const JobView = () => {
   }
 
   const id = params.id as string
+  const [errorFetch, setErrorFetch] = useState<AxiosError>()
 
   const runNow = (reset: boolean) => {
     runAdHoc(id, reset).then(
@@ -99,7 +102,7 @@ const JobView = () => {
           })
         })
         .catch((e) => {
-          errorHandler(e)
+          setErrorFetch(e)
         })
     }
   }
@@ -198,11 +201,12 @@ const JobView = () => {
           </Button>
         </Stack>
       )}
+      {job ? (
+          <>
       <PageHeader title="Job" description={description} />
       <Divider />
       <Stack direction="column" spacing={2}>
         <Paper sx={{ backgroundColor: 'background.default' }} elevation={0}>
-          {job ? (
             <Box
               sx={{
                 display: 'grid',
@@ -241,9 +245,6 @@ const JobView = () => {
                 />
               )}
             </Box>
-          ) : (
-            <CircularProgress data-testid="dataLoading" />
-          )}
         </Paper>
         <Stack direction="row" spacing={2}>
           {showTrigger && (
@@ -267,7 +268,20 @@ const JobView = () => {
             />
           )}
         </Stack>
+
       </Stack>
+          </>
+      ) : errorFetch?.response ? (
+          <ErrorAlert
+              specific="job"
+              statusCode={errorFetch.response?.status}
+              errorMsg={errorFetch.response.statusText}
+          />
+      ) : (
+          <Backdrop title="loading circle" open={true}>
+            <CircularProgress color="inherit" />
+          </Backdrop>
+      )}
       <ModalWrapper
         open={runOpen}
         header="Reset the Job Interval"

--- a/src/pages/RequestView/RequestView.test.tsx
+++ b/src/pages/RequestView/RequestView.test.tsx
@@ -134,16 +134,14 @@ describe('RequestView', () => {
 
   test('renders alert if error', async () => {
     jest.spyOn(Router, 'useParams').mockReturnValue({ id: mockId })
-    mockAxios.onGet('/api/v1/requests/1234').reply(400, {})
+    mockAxios.onGet('/api/v1/requests/1234').reply(404, {})
     render(
       <AllProviders>
         <RequestView />
       </AllProviders>,
     )
     await waitFor(() => {
-      expect(
-        screen.getByText('Request failed with status code 400'),
-      ).toBeInTheDocument()
+      expect(screen.getByText('Problem: Wrong identifier')).toBeInTheDocument()
     })
     mockAxios.onGet('/api/v1/requests/1234').reply(200, TRequest)
   })
@@ -157,7 +155,7 @@ describe('RequestView', () => {
       </AllProviders>,
     )
     await waitFor(() => {
-      expect(screen.getByTestId('dataLoading')).toBeInTheDocument()
+      expect(screen.getByTitle('dataLoading')).toBeInTheDocument()
     })
     mockAxios.onGet('/api/v1/requests/1234').reply(200, TRequest)
   })

--- a/src/pages/RequestView/RequestView.tsx
+++ b/src/pages/RequestView/RequestView.tsx
@@ -1,6 +1,5 @@
 import NavigateNextIcon from '@mui/icons-material/NavigateNext'
 import {
-  Alert,
   Backdrop,
   Breadcrumbs,
   CircularProgress,
@@ -9,6 +8,7 @@ import {
 } from '@mui/material'
 import useAxios from 'axios-hooks'
 import { Divider } from 'components/Divider'
+import { ErrorAlert } from 'components/ErrorAlert'
 import { JsonCard } from 'components/JsonCard'
 import { PageHeader } from 'components/PageHeader'
 import { ThemeContext } from 'components/UI/Theme/ThemeProvider'
@@ -67,7 +67,7 @@ const RequestView = () => {
     )
   }
 
-  return (
+  return request && !error ? (
     <>
       <RemakeRequestButton request={request} />
       <PageHeader title="Request View" description={String(id)} />
@@ -101,6 +101,16 @@ const RequestView = () => {
         ) : null}
       </Stack>
     </>
+  ) : error?.response ? (
+    <ErrorAlert
+      statusCode={error.response?.status}
+      specific="request"
+      errorMsg={error.response.statusText}
+    />
+  ) : (
+    <Backdrop title={'dataLoading'} open={true}>
+      <CircularProgress color="inherit" />
+    </Backdrop>
   )
 }
 

--- a/src/pages/RequestView/RequestView.tsx
+++ b/src/pages/RequestView/RequestView.tsx
@@ -57,16 +57,6 @@ const RequestView = () => {
     }
   }, [data, error])
 
-  if (!request) {
-    return error ? (
-      <Alert severity="error">{error.message}</Alert>
-    ) : (
-      <Backdrop open={true}>
-        <CircularProgress data-testid="dataLoading" color="inherit" />
-      </Backdrop>
-    )
-  }
-
   return request && !error ? (
     <>
       <RemakeRequestButton request={request} />

--- a/src/pages/RequestView/RequestView.tsx
+++ b/src/pages/RequestView/RequestView.tsx
@@ -93,7 +93,7 @@ const RequestView = () => {
     </>
   ) : error?.response ? (
     <ErrorAlert
-      statusCode={error.response?.status}
+      statusCode={error.response.status}
       specific="request"
       errorMsg={error.response.statusText}
     />

--- a/src/pages/RequestsIndex/RequestsIndex.tsx
+++ b/src/pages/RequestsIndex/RequestsIndex.tsx
@@ -170,7 +170,7 @@ const RequestsIndex = () => {
     </Box>
   ) : error?.response ? (
     <ErrorAlert
-      statusCode={error.response?.status}
+      statusCode={error.response.status}
       errorMsg={error.response.statusText}
     />
   ) : (

--- a/src/pages/RequestsIndex/RequestsIndex.tsx
+++ b/src/pages/RequestsIndex/RequestsIndex.tsx
@@ -1,7 +1,15 @@
 import RefreshIcon from '@mui/icons-material/Refresh'
 import { LoadingButton } from '@mui/lab'
-import { Box, Button, Checkbox, FormControlLabel } from '@mui/material'
+import {
+  Backdrop,
+  Box,
+  Button,
+  Checkbox,
+  CircularProgress,
+  FormControlLabel,
+} from '@mui/material'
 import { Divider } from 'components/Divider'
+import { ErrorAlert } from 'components/ErrorAlert'
 import { PageHeader } from 'components/PageHeader'
 import { SSRTable } from 'components/Table'
 import {
@@ -24,7 +32,7 @@ import {
 
 const RequestsIndex = () => {
   const {
-    requestData: { isLoading, isErrored, requests },
+    requestData: { isLoading, isErrored, requests, error },
     handlers: {
       handleIncludeChildren,
       handleShowHidden,
@@ -105,7 +113,7 @@ const RequestsIndex = () => {
     [searchByOnChange, orderingOnChange, handleResultCount, handleStartPage],
   )
 
-  return (
+  return !error ? (
     <Box>
       <PageHeader title="Requests" description="" />
       <Divider />
@@ -160,6 +168,15 @@ const RequestsIndex = () => {
         )}
       </SSRTable>
     </Box>
+  ) : error?.response ? (
+    <ErrorAlert
+      statusCode={error.response?.status}
+      errorMsg={error.response.statusText}
+    />
+  ) : (
+    <Backdrop open={true}>
+      <CircularProgress color="inherit" />
+    </Backdrop>
   )
 }
 

--- a/src/pages/RequestsIndex/requestsIndexData.tsx
+++ b/src/pages/RequestsIndex/requestsIndexData.tsx
@@ -219,6 +219,7 @@ const useRequests = () => {
       isLoading,
       isErrored,
       requests,
+      error,
     },
     handlers: {
       handleIncludeChildren,

--- a/src/pages/SystemAdmin/SystemAdmin.tsx
+++ b/src/pages/SystemAdmin/SystemAdmin.tsx
@@ -124,7 +124,7 @@ const SystemAdmin = () => {
     </Box>
   ) : error?.response ? (
     <ErrorAlert
-      statusCode={error.response?.status}
+      statusCode={error.response.status}
       errorMsg={error.response.statusText}
     />
   ) : (

--- a/src/pages/SystemAdmin/SystemAdmin.tsx
+++ b/src/pages/SystemAdmin/SystemAdmin.tsx
@@ -1,15 +1,17 @@
-import { Typography } from '@mui/material'
+import { Backdrop, CircularProgress, Typography } from '@mui/material'
 import { Alert, Box, Button, Grid, Tooltip } from '@mui/material'
+import { AxiosError } from 'axios'
 import { Divider } from 'components/Divider'
+import { ErrorAlert } from 'components/ErrorAlert'
 import { ModalWrapper } from 'components/ModalWrapper'
 import { PageHeader } from 'components/PageHeader'
 import useAdmin from 'hooks/useAdmin'
 import { useLocalStorage } from 'hooks/useLocalStorage'
-import useNamespace from 'hooks/useNamespace'
+import { useNamespace } from 'hooks/useNamespace'
 import useQueue from 'hooks/useQueue'
 import { NamespaceCard } from 'pages/SystemAdmin/NamespaceCard'
 import { NamespaceSelect } from 'pages/SystemAdmin/NamespaceSelect'
-import { createContext, useState } from 'react'
+import { createContext, useEffect, useState } from 'react'
 
 const getSelectMessage = (namespacesSelected: string[]): JSX.Element | void => {
   if (!namespacesSelected.length) {
@@ -38,24 +40,38 @@ const SystemAdmin = () => {
     [],
   )
   const [open, setOpen] = useState(false)
+  const { getNamespaces } = useNamespace()
 
-  const contextValue = {
-    namespaces: useNamespace(),
-    namespacesSelected: namespacesSelected,
-    setNamespacesSelected: setNamespacesSelected,
-  }
+  const [namespaces, setNamespaces] = useState<string[]>([])
+  const [error, setError] = useState<AxiosError>()
+  useEffect(() => {
+    getNamespaces()
+      .then((response) => {
+        setNamespaces(response.data)
+      })
+      .catch((error) => {
+        setError(error)
+      })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const { rescanPluginDirectory } = useAdmin()
   const { clearQueues } = useQueue()
 
-  return (
+  return !error ? (
     <Box>
       <Grid alignItems="start" justifyContent="space-between" container>
         <Grid key="header" item>
           <PageHeader title="Systems Management" description="" />
         </Grid>
         <Grid key="filter" item>
-          <NamespacesSelectedContext.Provider value={contextValue}>
+          <NamespacesSelectedContext.Provider
+            value={{
+              namespaces: namespaces,
+              namespacesSelected: namespacesSelected,
+              setNamespacesSelected: setNamespacesSelected,
+            }}
+          >
             <NamespaceSelect />
           </NamespacesSelectedContext.Provider>
         </Grid>
@@ -106,6 +122,15 @@ const SystemAdmin = () => {
       ))}
       {getSelectMessage(namespacesSelected)}
     </Box>
+  ) : error?.response ? (
+    <ErrorAlert
+      statusCode={error.response?.status}
+      errorMsg={error.response.statusText}
+    />
+  ) : (
+    <Backdrop open={true}>
+      <CircularProgress color="inherit" />
+    </Backdrop>
   )
 }
 

--- a/src/pages/SystemIndex/SystemIndex.test.tsx
+++ b/src/pages/SystemIndex/SystemIndex.test.tsx
@@ -52,11 +52,8 @@ describe('SystemIndex', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByText('Systems')).toBeInTheDocument()
+      expect(screen.getByText('Problem: Wrong identifier')).toBeInTheDocument()
     })
-
-    const errorMessage = 'ERROR: Error: Request failed with status code 404'
-    expect(screen.getByText(errorMessage)).toBeInTheDocument()
 
     mockAxios.onGet('/api/v1/systems').reply(200, [TSystem])
   })

--- a/src/pages/SystemIndex/SystemIndex.tsx
+++ b/src/pages/SystemIndex/SystemIndex.tsx
@@ -1,7 +1,8 @@
-import { Box } from '@mui/material'
+import { Backdrop, CircularProgress } from '@mui/material'
+import { AxiosError } from 'axios'
 import { Divider } from 'components/Divider'
+import { ErrorAlert } from 'components/ErrorAlert'
 import { PageHeader } from 'components/PageHeader'
-import { Snackbar } from 'components/Snackbar'
 import { Table } from 'components/Table'
 import { useSystems } from 'hooks/useSystems'
 import {
@@ -10,11 +11,10 @@ import {
 } from 'pages/SystemIndex'
 import { useEffect, useState } from 'react'
 import { System } from 'types/backend-types'
-import { SnackbarState } from 'types/custom-types'
 
 const SystemsIndex = () => {
   const [systems, setSystems] = useState<System[]>([])
-  const [alert, setAlert] = useState<SnackbarState | undefined>(undefined)
+  const [error, setError] = useState<AxiosError>()
   const { getSystems } = useSystems()
 
   useEffect(() => {
@@ -24,12 +24,7 @@ const SystemsIndex = () => {
         if (mounted) setSystems(response.data)
       })
       .catch((e) => {
-        if (mounted)
-          setAlert({
-            severity: 'error',
-            message: e,
-            doNotAutoDismiss: true,
-          })
+        if (mounted) setError(e)
       })
     return () => {
       mounted = false
@@ -37,19 +32,28 @@ const SystemsIndex = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  return (
+  const systemIndexTableData = useSystemIndexTableData(systems)
+  const systemIndexTableColumns = useSystemIndexTableColumns()
+
+  return !error ? (
     <>
-      <Box>
-        <PageHeader title="Systems" description="" />
-        <Divider />
-        <Table
-          tableKey="Systems"
-          data={useSystemIndexTableData(systems)}
-          columns={useSystemIndexTableColumns()}
-        />
-      </Box>
-      {alert && <Snackbar status={alert} />}
+      <PageHeader title="Systems" description="" />
+      <Divider />
+      <Table
+        tableKey="Systems"
+        data={systemIndexTableData}
+        columns={systemIndexTableColumns}
+      />
     </>
+  ) : error?.response ? (
+    <ErrorAlert
+      statusCode={error.response?.status}
+      errorMsg={error.response.statusText}
+    />
+  ) : (
+    <Backdrop open={true}>
+      <CircularProgress color="inherit" />
+    </Backdrop>
   )
 }
 

--- a/src/pages/SystemIndex/SystemIndex.tsx
+++ b/src/pages/SystemIndex/SystemIndex.tsx
@@ -47,7 +47,7 @@ const SystemsIndex = () => {
     </>
   ) : error?.response ? (
     <ErrorAlert
-      statusCode={error.response?.status}
+      statusCode={error.response.status}
       errorMsg={error.response.statusText}
     />
   ) : (

--- a/src/pages/UsersView/UsersView.test.tsx
+++ b/src/pages/UsersView/UsersView.test.tsx
@@ -23,7 +23,7 @@ const rolesUser = Object.assign({}, TUser, {
   role_assignments: [TRoleAssignment, TAdminRoleAssignment],
 })
 
-describe('UsersIndex', () => {
+describe('UsersView', () => {
   afterAll(() => {
     jest.unmock('react-router-dom')
     jest.clearAllMocks()

--- a/src/pages/UsersView/UsersView.tsx
+++ b/src/pages/UsersView/UsersView.tsx
@@ -2,15 +2,19 @@ import AddIcon from '@mui/icons-material/Add'
 import DeleteIcon from '@mui/icons-material/Delete'
 import SaveIcon from '@mui/icons-material/Save'
 import {
+  Backdrop,
   Box,
   Button,
+  CircularProgress,
   IconButton,
   Stack,
   TextField,
   Tooltip,
   Typography,
 } from '@mui/material'
+import { AxiosError } from 'axios'
 import { Divider } from 'components/Divider'
+import { ErrorAlert } from 'components/ErrorAlert'
 import { ModalWrapper } from 'components/ModalWrapper'
 import { PageHeader } from 'components/PageHeader'
 import { Snackbar } from 'components/Snackbar'
@@ -34,6 +38,7 @@ import { SnackbarState } from 'types/custom-types'
 export const UsersView = () => {
   const [open, setOpen] = useState(false)
   const [error, setError] = useState<boolean>(false)
+  const [errorFetch, setErrorFetch] = useState<AxiosError>()
   const [debounce, setDebounce] = useState<NodeJS.Timeout | undefined>()
   const [password, setPassword] = useState<string>('')
   const [confirm, setConfirm] = useState<string>('')
@@ -58,11 +63,7 @@ export const UsersView = () => {
         setSync(response.data.sync_status)
       })
       .catch((e) => {
-        setAlert({
-          severity: 'error',
-          message: e.response?.data.message || e,
-          doNotAutoDismiss: true,
-        })
+        setErrorFetch(e)
       })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userName])
@@ -96,7 +97,7 @@ export const UsersView = () => {
     setRoles(allRoles)
   }, [roles])
 
-  return (
+  return !errorFetch ? (
     <>
       {hasPermission('user:delete') && (
         <Tooltip title="Remove User">
@@ -237,5 +238,15 @@ export const UsersView = () => {
       </Tooltip>
       {alert && <Snackbar status={alert} />}
     </>
+  ) : errorFetch?.response ? (
+    <ErrorAlert
+      statusCode={errorFetch.response?.status}
+      specific="user"
+      errorMsg={errorFetch.response.statusText}
+    />
+  ) : (
+    <Backdrop open={true}>
+      <CircularProgress color="inherit" />
+    </Backdrop>
   )
 }


### PR DESCRIPTION
Closes #147 

I added an alert that will be shown instead of showing components with no data because there was an error to retrieving the data from the back-end. 

The alert should be shown if there was an error with getting the initial data for the page.

On the single garden, single job and single request pages, the alert should be shown with a 404 error when trying to navigate to an identifier that is not in the database.
For all the other pages if the back-end is shutdown the alert should be shown with a 500 error.