### PR TITLE
#260 - remove url base check

### DIFF
--- a/src/components/UI/NavigationBar/NavigationBar.tsx
+++ b/src/components/UI/NavigationBar/NavigationBar.tsx
@@ -45,9 +45,6 @@ const NavigationBar = ({ setMarginLeft }: NavigationBarProps) => {
 
   useEffect(() => {
     // Workaround to make the URL play nice
-    if (window.location.pathname !== '/') {
-      window.location.pathname = '/'
-    }
     if (!window.location.hash.startsWith('#/')) {
       window.location.hash = window.location.hash.replace(/^#[^/]+\//, '#/')
     }


### PR DESCRIPTION
Closes #260 

Removes a check that prevents "bad" base URLs (i.e. `4000:/bad/#/systems` still shows systems page). This check needs to be removed to allow for the "`/preview` hosting" that the production environment uses. The options were to whitelist `preview` specifically or just open up the base portion to anything knowing that there may be cases where extra characters are in the base URL that don't need to be there. Team discussion chose the latter as it allows users to host their production build however they like.