### PR TITLE
#245 - change how filters are applied

### DIFF
--- a/src/components/Table/SSRTable.tsx
+++ b/src/components/Table/SSRTable.tsx
@@ -393,7 +393,10 @@ const SSRTable = <
                     ...headerGroupProps
                   } = headerGroup.getHeaderGroupProps()
                   return (
-                    <TableRow key={headerGroupKey} {...headerGroupProps}>
+                    <TableRow
+                      key={headerGroupKey + 'Filter'}
+                      {...headerGroupProps}
+                    >
                       <>
                         {headerGroup.headers.map((column) => {
                           const {
@@ -402,7 +405,10 @@ const SSRTable = <
                             ...headerProps
                           } = column.getHeaderProps(columnStyle)
                           return (
-                            <TableHeadCell key={headerKey} {...headerProps}>
+                            <TableHeadCell
+                              key={headerKey + 'Filter'}
+                              {...headerProps}
+                            >
                               {column.canFilter && (
                                 <InlineFilter column={column} />
                               )}

--- a/src/components/Table/filters/TextFilter.tsx
+++ b/src/components/Table/filters/TextFilter.tsx
@@ -1,5 +1,4 @@
-import { TextField } from '@mui/material'
-import { useDebounce } from 'hooks/useDebounce'
+import { TextField, Tooltip } from '@mui/material'
 import { ChangeEvent, useEffect, useState } from 'react'
 import { FilterProps } from 'react-table'
 import { ObjectWithStringKeys } from 'types/custom-types'
@@ -7,29 +6,44 @@ import { ObjectWithStringKeys } from 'types/custom-types'
 export const TextFilter = ({ column }: FilterProps<ObjectWithStringKeys>) => {
   const { id, filterValue, setFilter } = column
   const [value, setValue] = useState(filterValue || '')
+  const [open, setOpen] = useState<boolean>(false)
 
   useEffect(() => {
     setValue(filterValue || '')
   }, [filterValue])
 
-  const debouncedValue = useDebounce(value, 500)
-  useEffect(() => {
-    setFilter(debouncedValue)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedValue])
-
   return (
-    <TextField
-      name={id}
-      hiddenLabel
-      size="small"
-      InputLabelProps={{ htmlFor: id }}
-      value={value}
-      variant="outlined"
-      onChange={(event: ChangeEvent<HTMLInputElement>) => {
-        setValue(event.target.value)
-      }}
-      onBlur={(event) => setFilter(event.target.value || undefined)}
-    />
+    <Tooltip
+      arrow
+      open={open}
+      title="Press Enter or click outside the input to submit."
+    >
+      <TextField
+        name={id}
+        hiddenLabel
+        size="small"
+        InputLabelProps={{ htmlFor: id }}
+        value={value}
+        variant="outlined"
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            setFilter(value || undefined)
+          }
+        }}
+        onFocus={() => {
+          setOpen(true)
+          setTimeout(() => {
+            setOpen(false)
+          }, 5000)
+        }}
+        onChange={(event: ChangeEvent<HTMLInputElement>) => {
+          setValue(event.target.value)
+        }}
+        onBlur={(event) => {
+          setFilter(event.target.value || undefined)
+          setOpen(false)
+        }}
+      />
+    </Tooltip>
   )
 }


### PR DESCRIPTION
Closes #245 

Filters were behaving oddly on the Requests page since it sends a call to the backend to actually do the filtering, triggering the entire page to be re-rendered. Removed the debounced auto-apply feature and replaced with lose focus or Enter key to "submit" filter. This applies to all tables for consistency. Added tooltip to remind users to click away or press Enter that disappears after a short window.