### PR TITLE
Null comment becomes empty string

### DIFF
--- a/src/pages/RequestView/RemakeRequestButton/RemakeRequestButton.tsx
+++ b/src/pages/RequestView/RemakeRequestButton/RemakeRequestButton.tsx
@@ -62,7 +62,7 @@ const RemakeRequestButton = ({ request }: RemakeRequestButtonProps) => {
   }
 
   const model: CommandViewRequestModel = {
-    comment: { comment: theComment } as CommandViewModelComment,
+    comment: { comment: theComment || '' } as CommandViewModelComment,
     instance_names: { instance_name: instanceName },
     parameters: theParameters as CommandViewModelParameters,
   }


### PR DESCRIPTION
To test, remake a request that has an empty comment and note that the form gives no feedback.