### PR TITLE
#205 Added unassociated runners to system admin page

### DIFF
--- a/src/hooks/useRunners.test.tsx
+++ b/src/hooks/useRunners.test.tsx
@@ -1,0 +1,55 @@
+import { waitFor } from '@testing-library/react'
+import { renderHook } from '@testing-library/react-hooks'
+import { useRunners } from 'hooks/useRunners'
+import { mockAxios } from 'test/axios-mock'
+import { TRunner } from 'test/system-test-values'
+import { ConfigProviders } from 'test/testMocks'
+
+describe('useRunners', () => {
+  test('getRunners gets Runners', async () => {
+    const { result } = renderHook(() => useRunners(), {
+      wrapper: ConfigProviders,
+    })
+    const response = await waitFor(() => {
+      return result.current.getRunners()
+    })
+    await waitFor(() => {
+      expect(response.data).toEqual([TRunner])
+    })
+  })
+
+  test('reloadSystem reloads the runner', async () => {
+    mockAxios.onGet('/api/vbeta/runners').reply(200, [TRunner])
+
+    const { result } = renderHook(() => useRunners(), {
+      wrapper: ConfigProviders,
+    })
+    const response = await waitFor(() => {
+      return result.current.getRunners()
+    })
+    await waitFor(() => {
+      expect(response.data).toEqual([TRunner])
+    })
+    expect(response.data[0].stopped).toBe(false)
+
+    const responseReload = await waitFor(() => {
+      return result.current.reloadRunner(TRunner.path)
+    })
+    await waitFor(() => {
+      expect(responseReload.data).toEqual([TRunner])
+    })
+  })
+
+  test('deleteRunner deletes the runner', async () => {
+    const { result } = renderHook(() => useRunners(), {
+      wrapper: ConfigProviders,
+    })
+
+    const responseDelete = await waitFor(() => {
+      return result.current.deleteRunner(TRunner.id)
+    })
+    await waitFor(() => {
+      expect(responseDelete.data).toEqual(TRunner)
+    })
+  })
+})

--- a/src/hooks/useRunners.tsx
+++ b/src/hooks/useRunners.tsx
@@ -1,0 +1,74 @@
+import { AxiosPromise, AxiosRequestConfig } from 'axios'
+import useAxios from 'axios-hooks'
+import { ServerConfigContainer } from 'containers/ConfigContainer'
+import { useMyAxios } from 'hooks/useMyAxios'
+import { Runner } from 'types/backend-types'
+
+const useRunners = () => {
+  const { authEnabled } = ServerConfigContainer.useContainer()
+  const { axiosManualOptions } = useMyAxios()
+  const [, execute] = useAxios({}, axiosManualOptions)
+
+  const getRunners = (): AxiosPromise<Runner[]> => {
+    const config: AxiosRequestConfig = {
+      url: '/api/vbeta/runners',
+      method: 'get',
+      withCredentials: authEnabled,
+    }
+
+    return execute(config)
+  }
+
+  const reloadRunner = (path: string) => {
+    const config: AxiosRequestConfig = {
+      url: '/api/vbeta/runners',
+      method: 'patch',
+      withCredentials: authEnabled,
+      data: { operation: 'reload', path: path },
+    }
+
+    return execute(config)
+  }
+
+  const stopRunner = (runnerId: string) => {
+    const config: AxiosRequestConfig = {
+      url: `/api/vbeta/runners/${runnerId}`,
+      method: 'patch',
+      withCredentials: authEnabled,
+      data: { operation: 'stop' },
+    }
+
+    return execute(config)
+  }
+
+  const startRunner = (runnerId: string) => {
+    const config: AxiosRequestConfig = {
+      url: `/api/vbeta/runners/${runnerId}`,
+      method: 'patch',
+      withCredentials: authEnabled,
+      data: { operation: 'start' },
+    }
+
+    return execute(config)
+  }
+
+  const deleteRunner = (runnerId: string) => {
+    const config: AxiosRequestConfig = {
+      url: `/api/vbeta/runners/${runnerId}`,
+      method: 'delete',
+      withCredentials: authEnabled,
+    }
+
+    return execute(config)
+  }
+
+  return {
+    getRunners,
+    reloadRunner,
+    stopRunner,
+    startRunner,
+    deleteRunner,
+  }
+}
+
+export { useRunners }

--- a/src/pages/SystemAdmin/SystemAdmin.tsx
+++ b/src/pages/SystemAdmin/SystemAdmin.tsx
@@ -11,9 +11,8 @@ import { useNamespace } from 'hooks/useNamespace'
 import useQueue from 'hooks/useQueue'
 import { NamespaceCard } from 'pages/SystemAdmin/NamespaceCard'
 import { NamespaceSelect } from 'pages/SystemAdmin/NamespaceSelect'
+import { UnassociatedRunnersCard } from 'pages/SystemAdmin/UnassociatedRunners'
 import { createContext, useEffect, useState } from 'react'
-
-import { UnassociatedRunnersCard } from './unassociatedRunners'
 
 const getSelectMessage = (namespacesSelected: string[]): JSX.Element | void => {
   if (!namespacesSelected.length) {

--- a/src/pages/SystemAdmin/SystemAdmin.tsx
+++ b/src/pages/SystemAdmin/SystemAdmin.tsx
@@ -13,6 +13,8 @@ import { NamespaceCard } from 'pages/SystemAdmin/NamespaceCard'
 import { NamespaceSelect } from 'pages/SystemAdmin/NamespaceSelect'
 import { createContext, useEffect, useState } from 'react'
 
+import { UnassociatedRunnersCard } from './unassociatedRunners'
+
 const getSelectMessage = (namespacesSelected: string[]): JSX.Element | void => {
   if (!namespacesSelected.length) {
     return <Alert severity="info">Please select a namespace</Alert>
@@ -120,6 +122,7 @@ const SystemAdmin = () => {
         styleOverrides={{ size: 'sm', top: '-55%' }}
       />
       <Divider />
+      <UnassociatedRunnersCard />
       {namespacesSelected.map((namespace: string) => (
         <NamespaceCard namespace={namespace} key={namespace + 'card'} />
       ))}

--- a/src/pages/SystemAdmin/UnassociatedRunners.test.tsx
+++ b/src/pages/SystemAdmin/UnassociatedRunners.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { UnassociatedRunnersCard } from 'pages/SystemAdmin/UnassociatedRunners'
+import { mockAxios } from 'test/axios-mock'
+import { TRunner, TRunner2 } from 'test/system-test-values'
+import { AllProviders } from 'test/testMocks'
+
+describe('UnassociatedRunnersCard', () => {
+  test('receives data with unassociated runners', async () => {
+    mockAxios.onGet('/api/vbeta/runners').reply(200, [TRunner, TRunner2])
+    render(
+      <AllProviders>
+        <UnassociatedRunnersCard />
+      </AllProviders>,
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Unassociated Local Runners')).toBeInTheDocument()
+    })
+    expect(screen.getByText(TRunner2.path)).toBeInTheDocument()
+    expect(screen.queryByText(TRunner.path)).not.toBeInTheDocument()
+  })
+
+  test('receives data without unassociated runners', async () => {
+    mockAxios.onGet('/api/vbeta/runners').reply(200, [TRunner])
+    render(
+      <AllProviders>
+        <UnassociatedRunnersCard />
+      </AllProviders>,
+    )
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Unassociated Local Runners'),
+      ).not.toBeInTheDocument()
+    })
+    expect(screen.queryByText(TRunner.path)).not.toBeInTheDocument()
+  })
+})

--- a/src/pages/SystemAdmin/UnassociatedRunners.tsx
+++ b/src/pages/SystemAdmin/UnassociatedRunners.tsx
@@ -114,7 +114,7 @@ const UnassociatedRunnersCard = () => {
           title="Click to collapse"
         >
           <Typography variant="h6" color="common.white" p={0.25}>
-            Unnassociated Local Runners
+            Unassociated Local Runners
           </Typography>
         </Alert>
         <Collapse in={expanded} timeout="auto" unmountOnExit>

--- a/src/pages/SystemAdmin/unassociatedRunners.tsx
+++ b/src/pages/SystemAdmin/unassociatedRunners.tsx
@@ -1,0 +1,253 @@
+import {
+  Cached as CachedIcon,
+  Delete as DeleteIcon,
+  PlayCircleFilled as PlayCircleFilledIcon,
+  Stop as StopIcon,
+} from '@mui/icons-material'
+import {
+  Alert,
+  Card,
+  CardActions,
+  CardContent,
+  Collapse,
+  Grid,
+  IconButton,
+  Toolbar,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import { Snackbar } from 'components/Snackbar'
+import { SocketContainer } from 'containers/SocketContainer'
+import { useRunners } from 'hooks/useRunners'
+import { alertStyle } from 'pages/SystemAdmin'
+import { useEffect, useState } from 'react'
+import { Runner } from 'types/backend-types'
+import { SnackbarState } from 'types/custom-types'
+
+const UnassociatedRunnersCard = () => {
+  const [unassociatedRunners, setUnassociatedRunners] = useState<Runner[]>([])
+  const [expanded, setExpanded] = useState(true)
+  const [alert, setAlert] = useState<SnackbarState | undefined>(undefined)
+  const { addCallback, removeCallback } = SocketContainer.useContainer()
+  const { getRunners, startRunner, stopRunner, reloadRunner, deleteRunner } =
+    useRunners()
+
+  const updateRunners = () => {
+    getRunners()
+      .then((response) => {
+        setUnassociatedRunners(
+          response.data.filter((element: Runner) => {
+            return element.instance_id === ''
+          }),
+        )
+      })
+      .catch((e) => {
+        setAlert({
+          severity: 'error',
+          message: e,
+          doNotAutoDismiss: true,
+        })
+      })
+  }
+
+  useEffect(() => {
+    let mounted = true
+    getRunners()
+      .then((response) => {
+        if (mounted) {
+          setUnassociatedRunners(
+            response.data.filter((element: Runner) => {
+              return element.instance_id === ''
+            }),
+          )
+        }
+      })
+      .catch((e) => {
+        setAlert({
+          severity: 'error',
+          message: e,
+          doNotAutoDismiss: true,
+        })
+      })
+    return () => {
+      mounted = false
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    addCallback('runner_updates', (event) => {
+      if (
+        event.name === 'RUNNER_STARTED' ||
+        event.name === 'RUNNER_STOPPED' ||
+        event.name === 'RUNNER_REMOVED'
+      ) {
+        updateRunners()
+      }
+    })
+    return () => {
+      removeCallback('system_updates')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [addCallback, removeCallback])
+
+  const data: { [key: string]: Runner[] } = {}
+  unassociatedRunners.forEach((runner: Runner) => {
+    if (data[runner.path]) {
+      data[runner.path].push(runner)
+    } else {
+      data[runner.path] = [runner]
+    }
+  })
+
+  return unassociatedRunners.length > 0 ? (
+    <>
+      <Card>
+        <Alert
+          variant="outlined"
+          sx={{
+            ...alertStyle,
+            backgroundColor: 'primary.main',
+          }}
+          severity="error"
+          onClick={() => setExpanded(!expanded)}
+          title="Click to collapse"
+        >
+          <Typography variant="h6" color="common.white" p={0.25}>
+            Unnassociated Local Runners
+          </Typography>
+        </Alert>
+        <Collapse in={expanded} timeout="auto" unmountOnExit>
+          <CardContent>
+            <Grid container flexWrap="wrap" flexDirection="row">
+              {Object.entries(data).map(([path, runners]) => (
+                <Grid item key={path} minWidth={0.1} p={0.25} maxWidth={0.3}>
+                  <Card sx={{ width: 1 }}>
+                    <Alert
+                      variant="outlined"
+                      sx={{
+                        ...alertStyle,
+                        backgroundColor: 'primary.main',
+                      }}
+                      severity="error"
+                      title={path}
+                    >
+                      <Typography variant="h6" color="common.white" p={0.25}>
+                        {path}
+                      </Typography>
+                    </Alert>
+                    <CardActions>
+                      <Grid item key={`${path}Actions`}>
+                        <Toolbar
+                          variant="dense"
+                          disableGutters
+                          sx={{ minHeight: 36 }}
+                        >
+                          <Tooltip
+                            arrow
+                            title="Start all instances"
+                            placement="bottom-start"
+                          >
+                            <IconButton
+                              size="small"
+                              onClick={() => {
+                                runners.map((runner: Runner) =>
+                                  startRunner(runner.id).catch((e) => {
+                                    setAlert({
+                                      severity: 'error',
+                                      message: e,
+                                      doNotAutoDismiss: true,
+                                    })
+                                  }),
+                                )
+                              }}
+                              aria-label="start"
+                            >
+                              <PlayCircleFilledIcon />
+                            </IconButton>
+                          </Tooltip>
+                          <Tooltip
+                            arrow
+                            title="Stop all instances"
+                            placement="bottom-start"
+                          >
+                            <IconButton
+                              size="small"
+                              onClick={() => {
+                                runners.map((runner: Runner) =>
+                                  stopRunner(runner.id).catch((e) => {
+                                    setAlert({
+                                      severity: 'error',
+                                      message: e,
+                                      doNotAutoDismiss: true,
+                                    })
+                                  }),
+                                )
+                              }}
+                              aria-label="stop"
+                            >
+                              <StopIcon />
+                            </IconButton>
+                          </Tooltip>
+                          <Tooltip
+                            arrow
+                            title="Reload system"
+                            placement="bottom-start"
+                          >
+                            <IconButton
+                              size="small"
+                              onClick={() => {
+                                reloadRunner(path).catch((e) => {
+                                  setAlert({
+                                    severity: 'error',
+                                    message: e,
+                                    doNotAutoDismiss: true,
+                                  })
+                                })
+                              }}
+                              aria-label="reload"
+                            >
+                              <CachedIcon />
+                            </IconButton>
+                          </Tooltip>
+                          <Tooltip
+                            arrow
+                            title="Delete system"
+                            placement="bottom-start"
+                          >
+                            <IconButton
+                              size="small"
+                              onClick={() => {
+                                runners.map((runner: Runner) =>
+                                  deleteRunner(runner.id).catch((e) => {
+                                    setAlert({
+                                      severity: 'error',
+                                      message: e,
+                                      doNotAutoDismiss: true,
+                                    })
+                                  }),
+                                )
+                              }}
+                              aria-label="delete"
+                            >
+                              <DeleteIcon />
+                            </IconButton>
+                          </Tooltip>
+                        </Toolbar>
+                      </Grid>
+                    </CardActions>
+                  </Card>
+                </Grid>
+              ))}
+            </Grid>
+          </CardContent>
+        </Collapse>
+      </Card>
+      {alert && <Snackbar status={alert} />}
+    </>
+  ) : (
+    <></>
+  )
+}
+
+export { UnassociatedRunnersCard }

--- a/src/test/axios-mock.ts
+++ b/src/test/axios-mock.ts
@@ -5,6 +5,7 @@ import {
   TBlockedCommand,
   TBlocklist,
   TInstance,
+  TRunner,
   TSystem,
 } from 'test/system-test-values'
 import * as mockData from 'test/test-values'
@@ -38,6 +39,7 @@ mock.onGet('/api/v1/users/adminUser').reply((config: AxiosRequestConfig) => {
 mock.onGet(regexLogs).reply(200, mockData.TLog, { request_id: 'fetchedLog' })
 mock.onGet(regexQueues).reply(200, [mockData.TQueue])
 mock.onGet('/api/v1/instances/testinst').reply(200, TInstance)
+mock.onGet('/api/vbeta/runners').reply(200, [TRunner])
 
 // Fail GET
 mock
@@ -68,6 +70,7 @@ mock
     return [200, Object.assign({}, mockData.TJob, { status: 'PAUSED' })]
   })
 mock.onPatch('/api/v1/systems/testsys').reply(200, '')
+mock.onPatch('/api/vbeta/runners').reply(200, [TRunner])
 
 // Success DELETE
 mock.onDelete(regexUsers).reply(204, '')
@@ -76,6 +79,7 @@ mock.onDelete('/api/v1/systems/testsys').reply(204)
 mock
   .onDelete(`/api/v1/commandpublishingblocklist/${TBlockedCommand.id}`)
   .reply(204, TBlockedCommand)
+mock.onDelete(`/api/vbeta/runners/${TRunner.id}`).reply(200, TRunner)
 
 // default
 mock.onAny().reply(200, 'undefined axios mock - add to axios-mock.ts')

--- a/src/test/system-test-values.ts
+++ b/src/test/system-test-values.ts
@@ -4,6 +4,7 @@ import {
   Command,
   Instance,
   Parameter,
+  Runner,
   System,
 } from 'types/backend-types'
 
@@ -124,4 +125,24 @@ export const TSystemCommand3 = {
   description: TCommand3.description,
   executeButton: expect.any(Object),
   isHidden: TCommand3.hidden,
+}
+
+export const TRunner: Runner = {
+  name: TSystem.name,
+  id: 'alive runner',
+  path: TSystem.name,
+  instance_id: 'instance id',
+  stopped: false,
+  dead: false,
+  restart: true,
+}
+
+export const TRunner2: Runner = {
+  name: TSystem2.name,
+  id: 'dead runner',
+  path: TSystem2.name,
+  instance_id: '',
+  stopped: false,
+  dead: true,
+  restart: false,
 }

--- a/src/types/backend-types.ts
+++ b/src/types/backend-types.ts
@@ -192,6 +192,16 @@ export interface System {
   metadata?: ObjectWithStringKeys | EmptyObject
 }
 
+export interface Runner {
+  name: string
+  id: string
+  path: string
+  instance_id: string
+  stopped: boolean
+  dead: boolean
+  restart: boolean
+}
+
 export type TriggerType = 'cron' | 'interval' | 'date'
 
 export interface CronTrigger {


### PR DESCRIPTION
Closes #205 

Added unassociated runners to system admin page. 

To test a plugin in must be in a state where it cannot start an instance. Adding an infinite loop to beginning of main in a plugin will cause the runner to not be associated to an instance.

If there are no unassociated runners the system admin page should load as normal.

If there are unassociated runners the unassociated runners will be displayed.

After fixing the problem in the plugin, clicking either the start, reload or the rescan buttons will update runner so it will no longer be dead. The runner should disappear after successfully starting.
