### PR TITLE
#306 - tweak disabled buttons in dark mode

### DIFF
--- a/src/components/LogModal.tsx
+++ b/src/components/LogModal.tsx
@@ -161,7 +161,7 @@ const LogModal = ({ instance, fileHeader }: ILogModal) => {
           <LoadingButton
             size="small"
             color="secondary"
-            variant="outlined"
+            variant="contained"
             loadingPosition="start"
             startIcon={<InsertDriveFile />}
             loading={isLoading}
@@ -200,7 +200,7 @@ const LogModal = ({ instance, fileHeader }: ILogModal) => {
         </Stack>
         <LoadingButton
           color="secondary"
-          variant="outlined"
+          variant="contained"
           loadingPosition="start"
           disabled={displayLogs.length === 0}
           startIcon={<FileDownload />}

--- a/src/components/UI/Theme/Theme.ts
+++ b/src/components/UI/Theme/Theme.ts
@@ -111,7 +111,6 @@ function getTheme(themeName: SupportedColorScheme) {
             active: dtext,
             hover: d4,
             disabled: d5,
-            focus: dtext,
           },
         },
       },

--- a/src/pages/RequestView/RemakeRequestButton/CannotReExecuteButton.tsx
+++ b/src/pages/RequestView/RemakeRequestButton/CannotReExecuteButton.tsx
@@ -1,20 +1,26 @@
 import { Button, Tooltip } from '@material-ui/core'
+import { useTheme } from '@mui/material/styles'
 
 interface CannotReExecuteButtonProps {
   message: string
 }
 
 const CannotReExecuteButton = ({ message }: CannotReExecuteButtonProps) => {
+  const theme = useTheme()
   return (
     <Tooltip title={message} data-testid="cannot-execute-button">
       <Button
         component="div"
         disabled
         variant="contained"
-        color="secondary"
-        style={{ float: 'right', pointerEvents: 'auto' }}
+        style={{
+          float: 'right',
+          pointerEvents: 'auto',
+          // theme style override not applying for some reason
+          color: theme.palette.action.disabled,
+        }}
       >
-        {'Remake Request'}
+        Remake Request
       </Button>
     </Tooltip>
   )

--- a/src/pages/RequestView/RemakeRequestButton/RemakeRequestButton.tsx
+++ b/src/pages/RequestView/RemakeRequestButton/RemakeRequestButton.tsx
@@ -102,7 +102,7 @@ const RemakeRequestButton = ({ request }: RemakeRequestButtonProps) => {
       style={{ float: 'right' }}
       onClick={onClick}
     >
-      {'Remake Request'}
+      Remake Request
     </Button>
   )
 }


### PR DESCRIPTION
Closes #306 

Could not reproduce the issue with button becoming disabled on JSON card close without turning on the linter, so nothing to fix there.

Color for disabled buttons slightly adjusted in dark mode. Had to specifically apply to the `Remake Request` button as it was not applying automatically for some reason.