### PR TITLE
#319 - disable filter row if no filters enabled

### DIFF
--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -58,7 +58,23 @@ describe('Table', () => {
     ).toBeInTheDocument()
   })
 
-  test('no filter if disabled', async () => {
+  test('no filters if all are disabled', async () => {
+    tableColumns[0].disableFilters = true
+    tableColumns[1].disableFilters = true
+    render(
+      <DebugProvider>
+        <Table
+          tableKey="Test"
+          data={tableData}
+          columns={tableColumns}
+          hideToolbar
+        />
+      </DebugProvider>,
+    )
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+  })
+
+  test('no filter if disabled for a column', async () => {
     tableColumns[1].disableFilters = true
     render(
       <DebugProvider>

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -285,7 +285,10 @@ const Table = <T extends ObjectWithStringKeys>(
         </TableHead>
         <TableBody {...getTableBodyProps()}>
           {/* Filter row */}
-          {!showGlobalFilter
+          {!showGlobalFilter &&
+          headerGroups.every((headerGroup) =>
+            headerGroup.headers.some((column) => column.canFilter),
+          )
             ? headerGroups.map((headerGroup) => {
                 const {
                   key: headerGroupKey,


### PR DESCRIPTION
Closes #319 

Adds check in table to not render filter row if there are no columns that are filterable