### PR TITLE
#312 changed form styling for create garden

### DIFF
--- a/src/components/GardenConnectionForm/GardenConnectionForm.tsx
+++ b/src/components/GardenConnectionForm/GardenConnectionForm.tsx
@@ -45,7 +45,10 @@ const GardenConnectionForm = ({
         onSubmit={useGardenConnectionFormOnSubmit(garden, formOnSubmit)}
       >
         <Form>
-          <fieldset disabled={!hasPermission('garden:update')}>
+          <fieldset
+            style={{ border: 0 }}
+            disabled={!hasPermission('garden:update')}
+          >
             <Typography variant="h3">{title}</Typography>
             {includeGardenName ? <GardenName /> : null}
             <ConnectionMethod />

--- a/src/components/GardenConnectionForm/garden-connection-form-components/ConnectionStompHeaders.tsx
+++ b/src/components/GardenConnectionForm/garden-connection-form-components/ConnectionStompHeaders.tsx
@@ -74,7 +74,7 @@ const ConnectionStompHeaders = () => {
               {hasPermission('garden:update') && (
                 <Button
                   type="button"
-                  color="primary"
+                  color="secondary"
                   onClick={() => {
                     push({ id: nanoid(), key: '', value: '' })
                   }}

--- a/src/pages/GardenAdmin/CreateGarden.tsx
+++ b/src/pages/GardenAdmin/CreateGarden.tsx
@@ -1,21 +1,9 @@
-import { Box, Button, Modal } from '@mui/material'
+import { Box, Button, Dialog } from '@mui/material'
 import { GardenConnectionForm } from 'components/GardenConnectionForm'
 import useGardens from 'hooks/useGardens'
 import { Dispatch, SetStateAction, useState } from 'react'
 import { Garden } from 'types/backend-types'
 import { SnackbarState } from 'types/custom-types'
-
-const modalStyle = {
-  position: 'absolute' as const,
-  top: '50%',
-  left: '50%',
-  transform: 'translate(-50%, -50%)',
-  bgcolor: 'background.paper',
-  boxShadow: 24,
-  p: 4,
-  height: '99%',
-  overflow: 'auto',
-}
 
 interface GardenConnectionFormProps {
   setRequestStatus: Dispatch<SetStateAction<SnackbarState | undefined>>
@@ -72,21 +60,20 @@ const CreateGarden = ({ setRequestStatus }: GardenConnectionFormProps) => {
       >
         Create Garden
       </Button>
-      <Modal
+      <Dialog
         open={open}
         onClose={() => setOpen(false)}
         aria-labelledby="modal-modal-title"
         aria-describedby="modal-modal-description"
+        maxWidth={'md'}
       >
-        <Box sx={modalStyle}>
-          <GardenConnectionForm
-            garden={garden}
-            title="Create Garden"
-            formOnSubmit={formOnSubmit}
-            includeGardenName={true}
-          />
-        </Box>
-      </Modal>
+        <GardenConnectionForm
+          garden={garden}
+          title="Create Garden"
+          formOnSubmit={formOnSubmit}
+          includeGardenName={true}
+        />
+      </Dialog>
     </Box>
   )
 }


### PR DESCRIPTION
Closes #312 

Changed create garden form so `Add header` button is easier to see.
Also changed the modal to a dialog so it is styled like other modals and reduced white space around the form in the modal.