### PR TITLE
#303 changed table header buttons to consistent styling

### DIFF
--- a/src/components/Table/defaults/DefaultGlobalFilter.tsx
+++ b/src/components/Table/defaults/DefaultGlobalFilter.tsx
@@ -28,7 +28,9 @@ const DefaultGlobalFilter = <T extends ObjectWithStringKeys>({
     <Box>
       <TextField
         type="search"
-        variant="filled"
+        variant="outlined"
+        size="small"
+        color="secondary"
         value={value || ''}
         onChange={(event) => {
           setValue(event.target.value)
@@ -37,7 +39,6 @@ const DefaultGlobalFilter = <T extends ObjectWithStringKeys>({
         placeholder={`Search ${count} records...`}
         sx={{
           fontSize: '1.1rem',
-          border: '0',
         }}
       />
     </Box>

--- a/src/pages/JobCreate/JobCreate.tsx
+++ b/src/pages/JobCreate/JobCreate.tsx
@@ -39,7 +39,13 @@ const JobCreate = () => {
   }
 
   const cancelAllSchedulingButton = (
-    <Button size="small" onClick={cancelJob} startIcon={<CancelIcon />}>
+    <Button
+      variant="contained"
+      color="secondary"
+      size="small"
+      onClick={cancelJob}
+      startIcon={<CancelIcon />}
+    >
       Cancel Scheduling
     </Button>
   )
@@ -76,6 +82,8 @@ const JobCreate = () => {
       >
         <Button
           size="small"
+          variant="contained"
+          color="secondary"
           onClick={backToSystem}
           startIcon={<ArrowBackIcon />}
         >

--- a/src/pages/JobIndex/JobIndex.tsx
+++ b/src/pages/JobIndex/JobIndex.tsx
@@ -127,7 +127,7 @@ const JobIndex = () => {
         {hasPermission('job:create') && (
           <Button
             variant="contained"
-            color="primary"
+            color="secondary"
             aria-label="Create Job"
             onClick={createRequestOnClick}
           >
@@ -137,7 +137,7 @@ const JobIndex = () => {
         {hasPermission('job:create') && (
           <Button
             variant="contained"
-            color="primary"
+            color="secondary"
             aria-label="Import Jobs"
             onClick={() => setOpenImport(true)}
           >
@@ -146,7 +146,7 @@ const JobIndex = () => {
         )}
         <Button
           variant="contained"
-          color="primary"
+          color="secondary"
           aria-label="Export Jobs"
           onClick={handleExport}
         >

--- a/src/pages/RequestsIndex/RequestsIndex.tsx
+++ b/src/pages/RequestsIndex/RequestsIndex.tsx
@@ -158,6 +158,7 @@ const RequestsIndex = () => {
           <LoadingButton
             size="small"
             color="secondary"
+            variant="contained"
             loadingIndicator="Loading..."
             loading={isLoading}
             startIcon={<RefreshIcon />}


### PR DESCRIPTION
Closes #303 

Change the table header buttons to have consistent styling as the table header buttons found on the jobs table. 