### PR TITLE
323 removed unnecessary eslint disable

### DIFF
--- a/src/containers/PermissionsContainer.tsx
+++ b/src/containers/PermissionsContainer.tsx
@@ -97,8 +97,7 @@ const usePermissions = () => {
     }
     return (
       globalPerms?.includes(permission) ||
-      // eslint-disable-next-line no-prototype-builtins
-      !!domainPerms?.hasOwnProperty(permission)
+      Object.prototype.hasOwnProperty.call(domainPerms, permission)
     )
   }
 
@@ -110,8 +109,11 @@ const usePermissions = () => {
     if (globalPerms?.includes(permission)) {
       return true
     }
-    // eslint-disable-next-line no-prototype-builtins
-    if (garden.id && domainPerms?.hasOwnProperty(permission)) {
+    if (
+      garden.id &&
+      domainPerms &&
+      Object.prototype.hasOwnProperty.call(domainPerms, permission)
+    ) {
       return domainPerms[permission].garden_ids.includes(garden.id)
     }
     return false
@@ -134,8 +136,10 @@ const usePermissions = () => {
     if (garden && hasGardenPermission(permission, garden)) {
       return true
     }
-    // eslint-disable-next-line no-prototype-builtins
-    if (domainPerms?.hasOwnProperty(permission)) {
+    if (
+      domainPerms &&
+      Object.prototype.hasOwnProperty.call(domainPerms, permission)
+    ) {
       return domainPerms[permission].system_ids.includes(systemId)
     }
     return false


### PR DESCRIPTION
Closes #323 

Changed `myObject.hasOwnProperty(somePropertyName)` to `Object.prototype.hasOwnProperty.call(myObject, somePropertyName)` so `eslint-disable-next-line no-prototype-builtins` is no longer needed and has been removed.
