### PR TITLE
#368 - Self-referencing dynamic choices

### DIFF
--- a/src/formHelpers/get-schema/schema-types.ts
+++ b/src/formHelpers/get-schema/schema-types.ts
@@ -1,3 +1,4 @@
+import { BasePickerProps } from '@mui/x-date-pickers/internals'
 import { JobPropertiesBasicSchema } from 'formHelpers'
 
 interface SingleInstance {
@@ -95,6 +96,7 @@ export type ParameterWithChoicesNonArraySchema = {
   type: ParameterSchemaBasicType
   enum: Array<string | number | object | null>
   isTypeAhead?: boolean
+  selfRefers?: boolean
 }
 
 export type ParameterWithChoicesSchema = ParameterBasicCommonSchema &

--- a/src/pages/CommandView/dynamic-form/dynamic-form-helpers/get-on-change-functions.ts
+++ b/src/pages/CommandView/dynamic-form/dynamic-form-helpers/get-on-change-functions.ts
@@ -121,6 +121,23 @@ const getOnChangeFunctions = (
           ),
         }
       }
+    } else if (
+      (isCommandChoiceWithArgs(parameter.choices) ||
+        isSimpleCommandChoice(parameter.choices)) &&
+      parameter.choices.display === 'typeahead'
+    ) {
+      if (parameterName in parametersThatCanInitiateUpdates) {
+        onChangeFunctions = {
+          ...onChangeFunctions,
+          [parameterName]: getOnChangeForDependency(
+            parameterName,
+            parametersThatCanInitiateUpdates[parameterName],
+            dynamicChoices,
+            parametersThatMustBeUpdatedNames,
+            stateManager,
+          ),
+        }
+      }
     }
   }
 
@@ -187,9 +204,8 @@ const getOnChangeForDependency = (
       )
     }
 
-    const updateDynamicState = () => {
+    const updateDynamicState = (selfRefers = false) => {
       const functions: VoidFunction[] = []
-
       for (const dynamicChoicesParameter of shouldUpdate) {
         const { args, commandProperties, dependsOn } =
           dynamicChoices[dynamicChoicesParameter]
@@ -208,9 +224,7 @@ const getOnChangeForDependency = (
           instance_name: instanceName,
           namespace: namespace,
           command: command,
-          command_type: 'INFO',
           parameters: commandParameters,
-          output_type: 'JSON',
         }
         const config: AxiosRequestConfig<RequestTemplate> = {
           url: '/api/v1/requests?blocking=true',
@@ -231,27 +245,28 @@ const getOnChangeForDependency = (
                   // update the model's value for the dynamic choice, the
                   // current value of the dynamic choice component and the
                   // form library's context for the dynamic parameter to zeroes
-                  stateManager.model.set((prev) => {
-                    return {
-                      ...prev,
-                      parameters: {
-                        ...prev.parameters,
-                        [dynamicChoicesParameter]: '',
-                      },
-                    }
-                  })
-                  stateManager.choice.set((prev) => {
-                    return {
-                      ...prev,
-                      [dynamicChoicesParameter]: {
-                        choice: '',
-                      },
-                    }
-                  })
-                  context.setFieldValue('parameters', {
-                    ...(context.values['parameters'] as ObjectWithStringKeys),
-                    [dynamicChoicesParameter]: '',
-                  })
+                  if (!selfRefers) {
+                    stateManager.model.set((prev) => {
+                      return {
+                        ...prev,
+                        parameters: {
+                          ...prev.parameters,
+                          [dynamicChoicesParameter]: '',
+                        },
+                      }
+                    })
+                  }
+
+                  if (!selfRefers) {
+                    stateManager.choice.set((prev) => {
+                      return {
+                        ...prev,
+                        [dynamicChoicesParameter]: {
+                          choice: '',
+                        },
+                      }
+                    })
+                  }
 
                   // update the choices that will be shown for the dynamic
                   // choices component
@@ -277,7 +292,7 @@ const getOnChangeForDependency = (
       }
     }
 
-    return (event: ChangeEvent<HTMLInputElement>) => {
+    return (event: ChangeEvent) => {
       if ('target' in event) {
         const target = event.target
 
@@ -286,13 +301,6 @@ const getOnChangeForDependency = (
             value: string
             name: string
           }
-
-          // update the form library's context object
-          const newContextParameters = {
-            ...(context.values['parameters'] as ObjectWithStringKeys),
-            [name]: value,
-          }
-          context.setFieldValue('parameters', newContextParameters)
 
           // update our tracked 'model' state
           stateManager.model.set((prev) => {
@@ -305,7 +313,11 @@ const getOnChangeForDependency = (
             }
           })
 
-          if (canUpdate()) updateDynamicState()
+          if (canUpdate()) {
+            const selfRefers =
+              'selfRefers' in target && Boolean(target['selfRefers'])
+            updateDynamicState(selfRefers)
+          }
         }
       }
     }
@@ -381,9 +393,7 @@ const getOnChangeForMustChoose = (
           instance_name: instanceName,
           namespace: namespace,
           command: command,
-          command_type: 'INFO',
           parameters: commandParameters,
-          output_type: 'JSON',
         }
         const config: AxiosRequestConfig<RequestTemplate> = {
           url: '/api/v1/requests?blocking=true',
@@ -422,10 +432,6 @@ const getOnChangeForMustChoose = (
                       },
                     }
                   })
-                  context.setFieldValue('parameters', {
-                    ...(context.values['parameters'] as ObjectWithStringKeys),
-                    [dynamicChoicesParameter]: '',
-                  })
 
                   // update the choices that will be shown for the dynamic
                   // choices component
@@ -451,7 +457,7 @@ const getOnChangeForMustChoose = (
       }
     }
 
-    return (event: ChangeEvent<HTMLInputElement>) => {
+    return (event: ChangeEvent) => {
       if ('target' in event) {
         const target = event.target
 
@@ -460,9 +466,6 @@ const getOnChangeForMustChoose = (
             value: string
             name: string
           }
-
-          // update the form library's context object
-          context.setFieldValue(name, value)
 
           // update our tracked 'ready' state
           stateManager.ready.set((prev) => {

--- a/src/pages/CommandView/dynamic-form/dynamic-form-types.ts
+++ b/src/pages/CommandView/dynamic-form/dynamic-form-types.ts
@@ -19,7 +19,7 @@ export interface DynamicProperties {
   dependsOn: string[]
 }
 
-export type OnChangeFunction = (e: ChangeEvent<HTMLInputElement>) => void
+export type OnChangeFunction = (e: ChangeEvent) => void
 
 export type OnChangeGetterFunction = <T extends Record<string, unknown>>(
   context: FormikContextType<T>,

--- a/src/types/backend-types.ts
+++ b/src/types/backend-types.ts
@@ -169,11 +169,11 @@ export interface RequestTemplate {
   instance_name: string
   namespace: string
   command: string
-  command_type: CommandType
+  command_type?: CommandType
   parameters: ObjectWithStringKeys | EmptyObject
   comment?: string
   metadata?: EmptyObject
-  output_type: OutputType
+  output_type?: OutputType
 }
 
 export interface System {


### PR DESCRIPTION
Closes #368 

### Testing
1. Again update `example_plugins`. There's a new command in `dynamic` and you can't verify behavior without having access to it.
2. Run `say_day`.  A good input is *sda* because it returns several entries. This demos item 1 of the ticket.
3. Run `self_referring_complicated`. The command doubles and triples the selected letter in the input if it exists. Try with, for example, 'b' and the string 'abcba'. This demos item 2 of the ticket.
4. They both demo item 3 of the ticket.

#### NOTE
The semantics of the typeahead is *non-strict*. This means it'll let you type in any old thing. But in the case of `say_day`, if you execute with anything but one of the returned values, the server throws an error. That's because the command is typed as *strict* in the plugin's definition, but we're ignoring it. This could be adapted to work both ways fairly easy. But for now, this should be good enough.