### PR TITLE
#235 - fix job trigger model

### DIFF
--- a/src/pages/CommandIndex/ExecuteButton.test.tsx
+++ b/src/pages/CommandIndex/ExecuteButton.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { mockAxios, regexUsers } from 'test/axios-mock'
+import { TAugmentedCommand } from 'test/request-command-job-test-values'
 import { TSystem } from 'test/system-test-values'
-import { TAugmentedCommand, TServerAuthConfig } from 'test/test-values'
+import { TServerAuthConfig } from 'test/test-values'
 import { LoggedInProviders } from 'test/testMocks'
 import { TAdmin, TUser } from 'test/user-test-values'
 

--- a/src/pages/CommandView/CommandView.test.tsx
+++ b/src/pages/CommandView/CommandView.test.tsx
@@ -1,21 +1,38 @@
-import { render, waitFor } from '@testing-library/react'
-import { screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import {
   emptyJobRequestCreationProviderState,
   JobRequestCreationContext,
   JobRequestCreationProviderState,
 } from 'components/JobRequestCreation'
 import * as commandViewHelpers from 'pages/CommandView/commandViewHelpers'
-import { TCommand, TSystem } from 'test/system-test-values'
+import {
+  TAugmentedCommand,
+  TRequestCommandModel,
+  TRequestJobModel,
+} from 'test/request-command-job-test-values'
+import { TParameter, TSystem } from 'test/system-test-values'
 import { AllProviders } from 'test/testMocks'
 import { AugmentedCommand, StrippedSystem } from 'types/custom-types'
-import {
-  CommandViewJob,
-  CommandViewJobModel,
-  CommandViewRequestModel,
-} from 'types/form-model-types'
+import { CommandViewRequestModel } from 'types/form-model-types'
 
 import { CommandView } from './CommandView'
+
+const { commands, ...theSystem } = TSystem
+const CommandContextValues: JobRequestCreationProviderState = {
+  ...emptyJobRequestCreationProviderState,
+  system: theSystem as StrippedSystem,
+  command: TAugmentedCommand,
+  isReplay: true,
+  requestModel: TRequestCommandModel,
+}
+const JobContextValues: JobRequestCreationProviderState = {
+  ...emptyJobRequestCreationProviderState,
+  system: theSystem as StrippedSystem,
+  command: TAugmentedCommand,
+  isJob: true,
+  isReplay: true,
+  requestModel: TRequestJobModel,
+}
 
 describe('CommandView', () => {
   let checkContext: jest.SpyInstance<
@@ -41,101 +58,44 @@ describe('CommandView', () => {
   afterEach(() => {
     checkContext.mockRestore()
   })
-  test('renders request form with model context values', async () => {
-    const testComment = 'Silly comment!'
-    const testParameterValue = 'This is a parameter value'
-    const { commands, ...theSystem } = TSystem
-    const theCommand: AugmentedCommand = {
-      ...TCommand,
-      namespace: theSystem.namespace,
-      systemName: theSystem.name,
-      systemVersion: theSystem.version,
-      systemId: theSystem.id,
-    }
-    const theRequestModel: CommandViewRequestModel = {
-      comment: {
-        comment: testComment,
-      },
-      instance_names: {
-        instance_name: TSystem.instances[0].name,
-      },
-      parameters: {
-        [theCommand.parameters[0].key]: testParameterValue,
-      },
-    }
-    const TContextValues: JobRequestCreationProviderState = {
-      ...emptyJobRequestCreationProviderState,
-      system: theSystem as StrippedSystem,
-      command: theCommand,
-      isReplay: true,
-      requestModel: theRequestModel,
-    }
 
+  test('renders request form with model context values', async () => {
     render(
       <AllProviders>
-        <JobRequestCreationContext.Provider value={TContextValues}>
+        <JobRequestCreationContext.Provider value={CommandContextValues}>
           <CommandView />
         </JobRequestCreationContext.Provider>
       </AllProviders>,
     )
-
     // comment is inserted
     await waitFor(() => {
-      expect(screen.getByDisplayValue(testComment)).toBeInTheDocument()
+      expect(
+        screen.getByDisplayValue(TRequestCommandModel.comment.comment),
+      ).toBeInTheDocument()
     })
-
+    console.log(TAugmentedCommand.parameters[0].key)
     // parameter value is inserted
+    const paramString = TRequestCommandModel.parameters[
+      TParameter.key
+    ] as string
     await waitFor(() => {
-      expect(screen.getByDisplayValue(testParameterValue)).toBeInTheDocument()
+      expect(screen.getByDisplayValue(paramString)).toBeInTheDocument()
     })
   })
 
   test('renders job form with model context values', async () => {
-    const jobName = 'My favorite job'
-    const { commands, ...theSystem } = TSystem
-    const theCommand: AugmentedCommand = {
-      ...TCommand,
-      namespace: theSystem.namespace,
-      systemName: theSystem.name,
-      systemVersion: theSystem.version,
-      systemId: theSystem.id,
-    }
-    const theCommandViewJob: CommandViewJob = {
-      name: jobName,
-      trigger: 'date',
-    }
-    const theRequestModel: CommandViewJobModel = {
-      comment: {
-        comment: '',
-      },
-      instance_names: {
-        instance_name: TSystem.instances[0].name,
-      },
-      parameters: {
-        [theCommand.parameters[0].key]: 'This is a parameter value',
-      },
-      job: theCommandViewJob,
-    }
-    const TContextValues: JobRequestCreationProviderState = {
-      ...emptyJobRequestCreationProviderState,
-      system: theSystem as StrippedSystem,
-      command: theCommand,
-      isJob: true,
-      isReplay: true,
-      requestModel: theRequestModel,
-    }
-
     render(
       <AllProviders>
-        <JobRequestCreationContext.Provider value={TContextValues}>
+        <JobRequestCreationContext.Provider value={JobContextValues}>
           <CommandView />
         </JobRequestCreationContext.Provider>
       </AllProviders>,
     )
-
     // job name is inserted
     await waitFor(() => {
-      expect(screen.getByDisplayValue(jobName)).toBeInTheDocument()
+      expect(
+        screen.getByDisplayValue(TRequestJobModel.job.name),
+      ).toBeInTheDocument()
     })
   })
 })

--- a/src/pages/CommandView/commandViewHelpers.test.tsx
+++ b/src/pages/CommandView/commandViewHelpers.test.tsx
@@ -1,17 +1,184 @@
+import { render, screen } from '@testing-library/react'
 import {
+  checkContext,
   commandIsDynamic,
+  fixReplayAny,
+  handleByteParametersReset,
+  isByteCommand,
   parameterHasDynamicChoiceProperties,
+  removeOldTriggerKeys,
 } from 'pages/CommandView/commandViewHelpers'
-import { dynamicCommandsList } from 'test/dynamic-choice-discriminators.test-values'
+import { HashRouter } from 'react-router-dom'
 import {
-  paramNoChoices,
-  paramWithStaticChoice,
+  dynamicCommandsList,
+  simpleDynamicCommand,
 } from 'test/dynamic-choice-discriminators.test-values'
+import { paramWithStaticChoice } from 'test/dynamic-choice-discriminators.test-values'
+import {
+  TAugmentedCommand,
+  TRequestCommandModel,
+  TRequestJobModel,
+} from 'test/request-command-job-test-values'
+import { TParameter, TSystem } from 'test/system-test-values'
+import { ParameterType } from 'types/backend-types'
+import { CommandViewRequestModel } from 'types/form-model-types'
 
-describe('hasDynamicChoiceProperties', () => {
+describe('checkContext', () => {
+  test('errors if no model for a replay', () => {
+    render(
+      <HashRouter>
+        {checkContext(
+          'namespace',
+          'sname',
+          'version',
+          'cname',
+          undefined,
+          undefined,
+          true,
+          undefined,
+        )}
+      </HashRouter>,
+    )
+    expect(
+      screen.getByText('IRRECOVERABLE ERROR IN RE-EXECUTION, GO TO systems'),
+    ).toBeInTheDocument()
+  })
+
+  test('errors if no namespace', () => {
+    render(
+      <HashRouter>
+        {checkContext(
+          undefined,
+          'sname',
+          'version',
+          'cname',
+          undefined,
+          undefined,
+          false,
+          undefined,
+        )}
+      </HashRouter>,
+    )
+    expect(screen.getByText('GO TO systems')).toBeInTheDocument()
+  })
+
+  test('errors if no systemName', () => {
+    render(
+      <HashRouter>
+        {checkContext(
+          'namespace',
+          undefined,
+          'version',
+          'cname',
+          undefined,
+          undefined,
+          false,
+          undefined,
+        )}
+      </HashRouter>,
+    )
+    expect(screen.getByText('GO TO systems : namespace')).toBeInTheDocument()
+  })
+
+  test('errors if no version', () => {
+    render(
+      <HashRouter>
+        {checkContext(
+          'namespace',
+          'sname',
+          undefined,
+          'cname',
+          undefined,
+          undefined,
+          false,
+          undefined,
+        )}
+      </HashRouter>,
+    )
+    expect(
+      screen.getByText('GO TO systems : namespace : sname'),
+    ).toBeInTheDocument()
+  })
+
+  test('errors if no commandName', () => {
+    render(
+      <HashRouter>
+        {checkContext(
+          'namespace',
+          'sname',
+          'version',
+          undefined,
+          undefined,
+          undefined,
+          false,
+          undefined,
+        )}
+      </HashRouter>,
+    )
+    expect(
+      screen.getByText('GO TO systems : namespace : sname'),
+    ).toBeInTheDocument()
+  })
+
+  test('errors if no system', () => {
+    render(
+      <HashRouter>
+        {checkContext(
+          'namespace',
+          'sname',
+          'version',
+          'cname',
+          undefined,
+          undefined,
+          false,
+          undefined,
+        )}
+      </HashRouter>,
+    )
+    expect(
+      screen.getByText('GO TO systems : namespace : sname'),
+    ).toBeInTheDocument()
+  })
+
+  test('errors if no command', () => {
+    render(
+      <HashRouter>
+        {checkContext(
+          'namespace',
+          'sname',
+          'version',
+          'cname',
+          TSystem,
+          undefined,
+          false,
+          undefined,
+        )}
+      </HashRouter>,
+    )
+    expect(
+      screen.getByText('GO TO systems : namespace : sname'),
+    ).toBeInTheDocument()
+  })
+
+  test('returns undefined if has all data', () => {
+    const renderElem = checkContext(
+      'namespace',
+      'sname',
+      'version',
+      'cname',
+      TSystem,
+      TAugmentedCommand,
+      false,
+      undefined,
+    )
+    expect(renderElem).toBeUndefined()
+  })
+})
+
+describe('parameterHasDynamicChoiceProperties', () => {
   describe('rejects non-dynamic parameters', () => {
     test('no choices', () => {
-      expect(parameterHasDynamicChoiceProperties(paramNoChoices)).toBe(false)
+      expect(parameterHasDynamicChoiceProperties(TParameter)).toBe(false)
     })
 
     test('parameter with only static choices', () => {
@@ -20,10 +187,79 @@ describe('hasDynamicChoiceProperties', () => {
       )
     })
   })
+
+  test('accepts dynamic parameter', () => {
+    expect(
+      parameterHasDynamicChoiceProperties(simpleDynamicCommand.parameters[0]),
+    ).toBe(true)
+  })
+})
+
+describe('handleByteParametersReset', () => {
+  test('does nothing if no params', () => {
+    const { parameters, ...noParamModel } = TRequestCommandModel
+    expect(
+      handleByteParametersReset(
+        TRequestCommandModel,
+        noParamModel as CommandViewRequestModel,
+        [],
+      ),
+    ).toEqual(TRequestCommandModel)
+  })
 })
 
 describe('commandIsDynamic', () => {
-  describe('accepts known dynamic commands from example plugins repo', () => {
+  test('accepts known dynamic commands from example plugins repo', () => {
     expect(dynamicCommandsList.every(commandIsDynamic)).toBe(true)
+  })
+})
+
+describe('isByteCommand', () => {
+  const byteParam = { ...TParameter, type: 'Bytes' as ParameterType }
+  const nestedParam = { ...TParameter, parameters: [byteParam] }
+
+  test('returns false if no byte parameter', () => {
+    expect(isByteCommand([TParameter])).toBe(false)
+  })
+
+  test('returns true if byte parameter', () => {
+    expect(isByteCommand([byteParam])).toBe(true)
+  })
+
+  test('returns true if nested byte parameter', () => {
+    expect(isByteCommand([nestedParam])).toBe(true)
+  })
+})
+
+describe('removeOldTriggerKeys', () => {
+  test('removes old trigger keys', () => {
+    const jobModel = {
+      ...TRequestJobModel,
+      job: {
+        name: 'My favorite job',
+        trigger: 'date',
+        timezone: 'UTC',
+        week: 2,
+        hour: 8,
+      },
+    }
+    const reqJobModel = { ...TRequestJobModel }
+    delete reqJobModel.job.timezone
+    removeOldTriggerKeys(jobModel, 'cron')
+    expect(jobModel).toEqual(reqJobModel)
+  })
+
+  test('does not remove trigger keys for unchanged trigger', () => {
+    const jbModel = { ...TRequestJobModel }
+    removeOldTriggerKeys(jbModel, 'date')
+    expect(jbModel).toEqual(TRequestJobModel)
+  })
+})
+
+describe('fixReplayAny', () => {
+  test('does not change non-dictionary and non-any type command models', () => {
+    expect(fixReplayAny(TRequestCommandModel, [TParameter])).toStrictEqual(
+      TRequestCommandModel,
+    )
   })
 })

--- a/src/pages/CommandView/commandViewHelpers.tsx
+++ b/src/pages/CommandView/commandViewHelpers.tsx
@@ -20,6 +20,7 @@ interface NavigatorProps {
   message: string
   link: string
 }
+
 /* This is an ugly placeholder */
 const Navigator = ({ message, link }: NavigatorProps) => {
   const navigate = useNavigate()
@@ -35,6 +36,7 @@ const Navigator = ({ message, link }: NavigatorProps) => {
     </Box>
   )
 }
+
 /*
     Sends us to a useful page if we came to CommandView using the wrong method.
  */
@@ -271,6 +273,65 @@ const cleanModelForDisplay = (
   return fixedModel
 }
 
+/**
+ * Removes old trigger related key/values from the model after the trigger
+ * type has been changed
+ * @param model
+ * @param oldTrigger
+ */
+const removeOldTriggerKeys = (model: CommandViewModel, oldTrigger?: string) => {
+  if (oldTrigger && oldTrigger !== (model as CommandViewJobModel).job.trigger) {
+    Object.keys((model as CommandViewJobModel).job).forEach((key: string) => {
+      if (key.startsWith(oldTrigger)) {
+        delete (model as CommandViewJobModel).job[key]
+      } else {
+        const baseKeys = ['start_date', 'end_date', 'timezone', 'jitter']
+        switch (oldTrigger) {
+          case 'cron': {
+            const cronKeys = [
+              'year',
+              'month',
+              'day',
+              'week',
+              'day_of_week',
+              'hour',
+              'minute',
+              'second',
+              ...baseKeys,
+            ]
+            if (cronKeys.includes(key)) {
+              delete (model as CommandViewJobModel).job[key]
+            }
+            break
+          }
+          case 'date': {
+            const dateKeys = ['run_date', 'timezone']
+            if (dateKeys.includes(key)) {
+              delete (model as CommandViewJobModel).job[key]
+            }
+            break
+          }
+          case 'interval': {
+            const intervalKeys = [
+              'reschedule_on_finish',
+              'days',
+              'weeks',
+              'hours',
+              'minutes',
+              'seconds',
+              ...baseKeys,
+            ]
+            if (intervalKeys.includes(key)) {
+              delete (model as CommandViewJobModel).job[key]
+            }
+            break
+          }
+        }
+      }
+    })
+  }
+}
+
 const dataUrlToFile = (dataUrl: string) => {
   const [preface, base64] = dataUrl.split(',')
   const [dataMimeType, filename] = preface.split(';')
@@ -387,4 +448,5 @@ export {
   handleByteParametersReset,
   isByteCommand,
   parameterHasDynamicChoiceProperties,
+  removeOldTriggerKeys,
 }

--- a/src/pages/CommandView/plain-form/CommandViewForm.tsx
+++ b/src/pages/CommandView/plain-form/CommandViewForm.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, ButtonGroup } from '@mui/material'
-import { ErrorSchema, FormValidation, IChangeEvent } from '@rjsf/core'
+import { FormValidation, IChangeEvent } from '@rjsf/core'
 import { MuiForm5 as Form } from '@rjsf/material-ui'
 import { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios'
 import useAxios from 'axios-hooks'
@@ -19,6 +19,7 @@ import {
   FileMetaData,
   handleByteParametersReset,
   isByteCommand,
+  removeOldTriggerKeys,
   TypeAheadChoicesWidget,
 } from 'pages/CommandView'
 import {
@@ -36,6 +37,7 @@ import {
   SnackbarState,
 } from 'types/custom-types'
 import {
+  CommandViewJobModel,
   CommandViewModel,
   CommandViewRequestModel,
 } from 'types/form-model-types'
@@ -102,11 +104,13 @@ const CommandViewForm = ({
     )
   }
 
-  const onFormUpdated = (
-    changeEvent: IChangeEvent,
-    es: ErrorSchema | undefined,
-  ) => {
+  const onFormUpdated = (changeEvent: IChangeEvent) => {
     const formData = changeEvent.formData as CommandViewModel
+    if (isJob) {
+      const oldTrigger = (displayModel as CommandViewJobModel).job.trigger
+      removeOldTriggerKeys(formData, oldTrigger)
+    }
+
     setModel(formData)
 
     const cleanedModel = cleanModelForDisplay(

--- a/src/test/dynamic-choice-discriminators.test-values.ts
+++ b/src/test/dynamic-choice-discriminators.test-values.ts
@@ -1,15 +1,5 @@
+import { TParameter } from 'test/system-test-values'
 import { Choice, Command, Parameter } from 'types/backend-types'
-
-export const paramNoChoices: Parameter = {
-  key: 'paramKey',
-  type: 'String',
-  multi: false,
-  display_name: 'paramDisplayName',
-  optional: false,
-  parameters: [],
-  nullable: true,
-  choices: undefined,
-}
 
 export const staticChoice: Choice = {
   display: 'select',
@@ -20,7 +10,7 @@ export const staticChoice: Choice = {
 }
 
 export const paramWithStaticChoice: Parameter = {
-  ...paramNoChoices,
+  ...TParameter,
   choices: staticChoice,
 }
 

--- a/src/test/request-command-job-test-values.ts
+++ b/src/test/request-command-job-test-values.ts
@@ -1,0 +1,43 @@
+import { TCommand, TSystem } from 'test/system-test-values'
+import { AugmentedCommand } from 'types/custom-types'
+import {
+  CommandViewJobModel,
+  CommandViewRequestModel,
+} from 'types/form-model-types'
+
+export const TAugmentedCommand: AugmentedCommand = {
+  ...TCommand,
+  namespace: TSystem.namespace,
+  systemName: TSystem.name,
+  systemVersion: TSystem.version,
+  systemId: TSystem.id,
+}
+
+export const TRequestCommandModel: CommandViewRequestModel = {
+  comment: {
+    comment: 'Silly comment!',
+  },
+  instance_names: {
+    instance_name: TSystem.instances[0].name,
+  },
+  parameters: {
+    [TAugmentedCommand.parameters[0].key]: 'This is a parameter value',
+  },
+}
+
+export const TRequestJobModel: CommandViewJobModel = {
+  comment: {
+    comment: 'Silly JOB comment!',
+  },
+  instance_names: {
+    instance_name: TSystem.instances[0].name,
+  },
+  parameters: {
+    [TAugmentedCommand.parameters[0].key]: 'This is a JOB parameter value',
+  },
+  job: {
+    name: 'My favorite job',
+    trigger: 'date',
+    timezone: 'UTC'
+  },
+}

--- a/src/test/system-test-values.ts
+++ b/src/test/system-test-values.ts
@@ -16,6 +16,7 @@ export const TParameter: Parameter = {
   optional: true,
   parameters: [],
   nullable: false,
+  choices: undefined,
 }
 
 export const TCommand: Command = {

--- a/src/test/test-values.ts
+++ b/src/test/test-values.ts
@@ -8,7 +8,6 @@ import {
   Request,
   RequestTemplate,
 } from 'types/backend-types'
-import { AugmentedCommand } from 'types/custom-types'
 
 export const TServerConfig = {
   application_name: 'testApp',
@@ -64,13 +63,6 @@ export const TJob: Job = {
   trigger: {} as DateTrigger,
   trigger_type: 'date',
 }
-
-export const TAugmentedCommand: AugmentedCommand = Object.assign({}, TCommand, {
-  namespace: 'someNamespace',
-  systemName: TSystem.name,
-  systemVersion: TSystem.version,
-  systemId: TSystem.id,
-})
 
 export const TQueue: Queue = {
   version: '1.0.2',

--- a/src/types/form-model-types.ts
+++ b/src/types/form-model-types.ts
@@ -39,6 +39,7 @@ export interface CommandViewRequestModel {
 }
 
 export type CommandViewJob = {
+  [index: string]: number | string | boolean | undefined
   coalesce?: boolean
   max_instances?: number
   misfire_grace_time?: number


### PR DESCRIPTION
Closes #235 

Changing trigger type when creating a job now does not carry over old trigger-specific key/value pairs. Added extra testing for other functions in touched files and a bit of test refactoring.