### PR TITLE
#375 - missing execute button fix

### DIFF
--- a/src/containers/PermissionsContainer.tsx
+++ b/src/containers/PermissionsContainer.tsx
@@ -79,7 +79,7 @@ const usePermissions = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user])
 
-  const basePermissionCheck = (): boolean | undefined => {
+  const basePermissionCheck = useCallback((): boolean | undefined => {
     if (DEBUG_PERMISSION) {
       console.log('authEnabled', authEnabled)
       console.log('globalPerms', globalPerms)
@@ -89,7 +89,7 @@ const usePermissions = () => {
     if (!globalPerms) return false
     if (!domainPerms) return false
     return undefined
-  }
+  }, [DEBUG_PERMISSION, authEnabled, domainPerms, globalPerms])
 
   const hasPermission = (permission: string): boolean => {
     const baseCheck = basePermissionCheck()
@@ -102,73 +102,88 @@ const usePermissions = () => {
     )
   }
 
-  const hasGardenPermission = (permission: string, garden: Garden): boolean => {
-    const baseCheck = basePermissionCheck()
-    if (typeof baseCheck !== 'undefined') {
-      return !!baseCheck
-    }
-    if (globalPerms?.includes(permission)) {
-      return true
-    }
-    if (
-      garden.id &&
-      domainPerms &&
-      Object.prototype.hasOwnProperty.call(domainPerms, permission)
-    ) {
-      return domainPerms[permission].garden_ids.includes(garden.id)
-    }
-    return false
-  }
+  const hasGardenPermission = useCallback(
+    (permission: string, garden: Garden): boolean => {
+      const baseCheck = basePermissionCheck()
+      if (typeof baseCheck !== 'undefined') {
+        return !!baseCheck
+      }
+      if (globalPerms?.includes(permission)) {
+        return true
+      }
+      if (
+        garden.id &&
+        domainPerms &&
+        Object.prototype.hasOwnProperty.call(domainPerms, permission)
+      ) {
+        return domainPerms[permission].garden_ids.includes(garden.id)
+      }
+      return false
+    },
+    [basePermissionCheck, domainPerms, globalPerms],
+  )
 
-  const hasSystemPermission = async (
-    permission: string,
-    namespace: string,
-    systemId: string,
-  ): Promise<boolean> => {
-    const baseCheck = basePermissionCheck()
-    if (typeof baseCheck !== 'undefined') {
-      return !!baseCheck
-    }
-    if (globalPerms?.includes(permission)) {
-      return true
-    }
-    const response = await getGarden(namespace)
-    const garden = response.data
-    if (garden && hasGardenPermission(permission, garden)) {
-      return true
-    }
-    if (
-      domainPerms &&
-      Object.prototype.hasOwnProperty.call(domainPerms, permission)
-    ) {
-      return domainPerms[permission].system_ids.includes(systemId)
-    }
-    return false
-  }
+  const hasSystemPermission = useCallback(
+    async (
+      permission: string,
+      namespace: string,
+      systemId: string,
+    ): Promise<boolean> => {
+      const baseCheck = basePermissionCheck()
+      if (typeof baseCheck !== 'undefined') {
+        return !!baseCheck
+      }
+      if (globalPerms?.includes(permission)) {
+        return true
+      }
+      const response = await getGarden(namespace)
+      const garden = response.data
+      if (garden && hasGardenPermission(permission, garden)) {
+        return true
+      }
+      if (
+        domainPerms &&
+        Object.prototype.hasOwnProperty.call(domainPerms, permission)
+      ) {
+        return domainPerms[permission].system_ids.includes(systemId)
+      }
+      return false
+    },
+    [
+      basePermissionCheck,
+      domainPerms,
+      getGarden,
+      globalPerms,
+      hasGardenPermission,
+    ],
+  )
 
-  const hasJobPermission = async (permission: string, job: Job) => {
-    const baseCheck = basePermissionCheck()
-    if (typeof baseCheck !== 'undefined') {
-      return !!baseCheck
-    }
-    const response = await getSystems()
-    const systems: System[] = response.data
-    const foundSystem = systems.find(
-      (system) =>
-        system.namespace === job.request_template.namespace &&
-        system.version === job.request_template.system_version &&
-        system.name === job.request_template.system,
-    )
-    if (foundSystem) {
-      const systemPerm = await hasSystemPermission(
-        permission,
-        job.request_template.namespace,
-        foundSystem.id,
+  const hasJobPermission = useCallback(
+    async (permission: string, job: Job) => {
+      const baseCheck = basePermissionCheck()
+      if (typeof baseCheck !== 'undefined') {
+        return !!baseCheck
+      }
+      const response = await getSystems()
+      const systems: System[] = response.data
+      const foundSystem = systems.find(
+        (system) =>
+          system.namespace === job.request_template.namespace &&
+          system.version === job.request_template.system_version &&
+          system.name === job.request_template.system,
       )
-      return systemPerm
-    }
-    return false
-  }
+      if (foundSystem) {
+        const systemPerm = await hasSystemPermission(
+          permission,
+          job.request_template.namespace,
+          foundSystem.id,
+        )
+        return systemPerm
+      }
+      return false
+    },
+    [basePermissionCheck, getSystems, hasSystemPermission],
+  )
 
   return {
     hasPermission,

--- a/src/pages/CommandIndex/ExecuteButton.tsx
+++ b/src/pages/CommandIndex/ExecuteButton.tsx
@@ -24,8 +24,7 @@ const ExecuteButton = ({ system, command }: IExeButton) => {
       setPermission(permCheck || false)
     }
     fetchPermission()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [namespace, systemId])
+  }, [hasSystemPermission, namespace, systemId])
 
   const linkTo = [
     '/systems',

--- a/src/pages/CommandIndex/commandIndexHelpers.tsx
+++ b/src/pages/CommandIndex/commandIndexHelpers.tsx
@@ -4,100 +4,58 @@ import { useMemo } from 'react'
 import { Column } from 'react-table'
 import { CommandIndexTableData } from 'types/custom-types'
 
-const useCommandIndexTableColumns = (showExecute = false) => {
+const useCommandIndexTableColumns = () => {
   return useMemo<Column<CommandIndexTableData>[]>(() => {
-    if (!showExecute) {
-      return [
-        {
-          Header: 'Namespace',
-          accessor: 'namespace',
-          minWidth: 120,
-          maxWidth: 180,
-          width: 130,
-        },
-        {
-          Header: 'System',
-          accessor: 'system',
-          filter: 'fuzzyText',
-          minWidth: 90,
-          maxWidth: 150,
-          width: 110,
-        },
-        {
-          Header: 'Version',
-          accessor: 'version',
-          minWidth: 90,
-          maxWidth: 120,
-          width: 100,
-        },
-        {
-          Header: 'Command',
-          accessor: 'command',
-          Cell: HiddenRenderer,
-          minWidth: 90,
-          maxWidth: 350,
-          width: 300,
-        },
-        {
-          Header: 'Description',
-          accessor: 'description',
-          minWidth: 90,
-          maxWidth: 500,
-          width: 300,
-        },
-      ]
-    } else {
-      return [
-        {
-          Header: 'Namespace',
-          accessor: 'namespace',
-          minWidth: 120,
-          maxWidth: 180,
-          width: 130,
-        },
-        {
-          Header: 'System',
-          accessor: 'system',
-          filter: 'fuzzyText',
-          minWidth: 90,
-          maxWidth: 150,
-          width: 110,
-        },
-        {
-          Header: 'Version',
-          accessor: 'version',
-          minWidth: 90,
-          maxWidth: 120,
-          width: 100,
-        },
-        {
-          Header: 'Command',
-          accessor: 'command',
-          Cell: HiddenRenderer,
-          minWidth: 90,
-          maxWidth: 350,
-          width: 300,
-        },
-        {
-          Header: 'Description',
-          accessor: 'description',
-          minWidth: 90,
-          maxWidth: 500,
-          width: 300,
-        },
-        {
-          Header: 'Action',
-          accessor: 'executeButton',
-          Cell: DefaultCellRenderer,
-          disableSortBy: true,
-          disableGroupBy: true,
-          disableFilters: true,
-          canHide: false,
-          width: 95,
-        },
-      ]
-    }
-  }, [showExecute])
+    return [
+      {
+        Header: 'Namespace',
+        accessor: 'namespace',
+        minWidth: 120,
+        maxWidth: 180,
+        width: 130,
+      },
+      {
+        Header: 'System',
+        accessor: 'system',
+        filter: 'fuzzyText',
+        minWidth: 90,
+        maxWidth: 150,
+        width: 110,
+      },
+      {
+        Header: 'Version',
+        accessor: 'version',
+        minWidth: 90,
+        maxWidth: 120,
+        width: 100,
+      },
+      {
+        Header: 'Command',
+        accessor: 'command',
+        Cell: HiddenRenderer,
+        minWidth: 90,
+        maxWidth: 350,
+        width: 300,
+      },
+      {
+        Header: 'Description',
+        accessor: 'description',
+        minWidth: 90,
+        maxWidth: 500,
+        width: 300,
+      },
+      {
+        Header: 'Action',
+        accessor: 'executeButton',
+        Cell: DefaultCellRenderer,
+        disableSortBy: true,
+        disableGroupBy: true,
+        disableFilters: true,
+        canHide: false,
+        width: 95,
+      },
+    ]
+  }, [])
 }
 
 export { useCommandIndexTableColumns }

--- a/src/pages/RequestView/RequestView.tsx
+++ b/src/pages/RequestView/RequestView.tsx
@@ -13,6 +13,7 @@ import { JsonCard } from 'components/JsonCard'
 import { PageHeader } from 'components/PageHeader'
 import { ThemeContext } from 'components/UI/Theme/ThemeProvider'
 import { ServerConfigContainer } from 'containers/ConfigContainer'
+import { PermissionsContainer } from 'containers/PermissionsContainer'
 import { SocketContainer } from 'containers/SocketContainer'
 import { useMountedState } from 'hooks/useMountedState'
 import { RequestViewOutput, RequestViewTable } from 'pages/RequestView'
@@ -23,6 +24,7 @@ import { useParams } from 'react-router-dom'
 import { Request } from 'types/backend-types'
 
 const RequestView = () => {
+  const { hasPermission } = PermissionsContainer.useContainer()
   const { authEnabled } = ServerConfigContainer.useContainer()
   const theme = useContext(ThemeContext).theme
   const [request, setRequest] = useMountedState<Request | undefined>()
@@ -60,7 +62,7 @@ const RequestView = () => {
 
   return request && !error ? (
     <>
-      <RemakeRequestButton request={request} />
+      {hasPermission('job:create') && <RemakeRequestButton request={request} />}
       <PageHeader title="Request View" description={String(id)} />
       <Divider />
       {request.parent ? (

--- a/src/utils/commandFormatters.tsx
+++ b/src/utils/commandFormatters.tsx
@@ -4,7 +4,6 @@ import { CommandIndexTableData, SystemCommandPair } from 'types/custom-types'
 
 const commandMapper = (pair: SystemCommandPair): CommandIndexTableData => {
   const { system, command } = pair
-
   return {
     namespace: command.namespace,
     system: command.systemName,


### PR DESCRIPTION
Closes #375 

Command Index table no longer hides button column if there are no permissions. If you are on a namespace only level, a permission check inaccurately comes back as false and the column is hid. If the permission is checked on a per-button basis, the check is accurate.