### PR TITLE
#363 - fix unit tests

### DIFF
--- a/src/components/Routes/Routes.test.tsx
+++ b/src/components/Routes/Routes.test.tsx
@@ -18,16 +18,11 @@ jest.mock('jwt-decode', () => () => ({
   exp: 9999912345,
 }))
 
-afterAll(() => {
-  jest.unmock('react-router-dom')
-  jest.unmock('jwt-decode')
-  jest.clearAllMocks()
-})
-
-describe('Routes basics', () => {
-  beforeAll(() => {
-    mockAxios.onGet('/config').reply(200, TServerConfig)
-    mockAxios.onGet(regexUsers).reply(200, TAdmin)
+describe('Routes', () => {
+  afterAll(() => {
+    jest.unmock('react-router-dom')
+    jest.unmock('jwt-decode')
+    jest.clearAllMocks()
   })
 
   test('Systems is default page', async () => {
@@ -45,385 +40,395 @@ describe('Routes basics', () => {
       screen.getByRole('heading', { name: 'Systems' }).textContent,
     ).toEqual('Systems')
   })
-})
 
-describe('Routes with auth disabled', () => {
-  beforeAll(() => {
-    mockAxios.onGet('/config').reply(200, TServerConfig)
-    mockAxios.onGet(regexUsers).reply(200, TAdmin)
+  describe('auth disabled', () => {
+    beforeAll(() => {
+      mockAxios.onGet('/config').reply(200, TServerConfig)
+      mockAxios.onGet(regexUsers).reply(200, TAdmin)
+    })
+
+    test('Systems should be accessible', async () => {
+      render(
+        <MemoryProvider startLocation={['/systems']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { name: 'Systems' }),
+        ).toBeInTheDocument()
+      })
+    })
+
+    test('Requests should be accessible', async () => {
+      render(
+        <MemoryProvider startLocation={['/requests']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { name: 'Requests' }),
+        ).toBeInTheDocument()
+      })
+    })
+
+    test('Users should not be accessible', async () => {
+      render(
+        <MemoryProvider startLocation={['/admin/users']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('heading', { name: 'User Management' }),
+        ).not.toBeInTheDocument(),
+      )
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { name: 'Systems' }),
+        ).toBeInTheDocument()
+      })
+    })
+
+    test('Job should be accessible', async () => {
+      render(
+        <MemoryProvider startLocation={['/jobs']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { name: 'Request Scheduler' }),
+        ).toBeInTheDocument()
+      })
+    })
+
+    test('System Admin should be accessible', async () => {
+      render(
+        <MemoryProvider startLocation={['/admin/systems']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { name: 'Systems Management' }),
+        ).toBeInTheDocument()
+      })
+    })
+
+    test('Garden Admin should be accessible', async () => {
+      render(
+        <MemoryProvider startLocation={['/admin/gardens']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { name: 'Gardens Management' }),
+        ).toBeInTheDocument()
+      })
+    })
+
+    test('Command Blocklist should be accessible', async () => {
+      jest
+        .spyOn(Router, 'useParams')
+        .mockReturnValue({ systemName: TSystem.name })
+      render(
+        <MemoryProvider startLocation={['/admin/commandblocklist']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', {
+            name: 'Command Publishing Blocklist',
+          }),
+        ).toBeInTheDocument()
+      })
+    })
+
+    test('Login should not be accessible', async () => {
+      jest
+        .spyOn(Router, 'useParams')
+        .mockReturnValue({ systemName: TSystem.name })
+      render(
+        <MemoryProvider startLocation={['/login']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { name: 'Systems' }),
+        ).toBeInTheDocument()
+      })
+    })
   })
 
-  test('Systems should be accessible', async () => {
-    render(
-      <MemoryProvider startLocation={['/systems']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() => {
+  describe('auth enabled, no access', () => {
+    beforeAll(() => {
+      mockAxios.onGet('/config').reply(200, TServerAuthConfig)
+      mockAxios.onGet(regexUsers).reply(200, TUser)
+    })
+
+    afterAll(() => {
+      mockAxios.onGet('/config').reply(200, TServerConfig)
+    })
+
+    test('Systems should be accessible', async () => {
+      render(
+        <MemoryProvider startLocation={['/systems']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() => {
+        expect(screen.getByLabelText('Password *')).toBeInTheDocument()
+      })
+      // For some reason have to do this only once
+      loginFN()
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { name: 'Systems' }),
+        ).toBeInTheDocument()
+      })
+    })
+
+    test('Requests should be accessible', async () => {
+      render(
+        <MemoryProvider startLocation={['/requests']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { name: 'Requests' }),
+        ).toBeInTheDocument()
+      })
+    })
+
+    test('Users should not be accessible', async () => {
+      render(
+        <MemoryProvider startLocation={['/admin/users']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('heading', { name: 'User Management' }),
+        ).not.toBeInTheDocument(),
+      )
+      expect(
+        screen.getByRole('heading', { name: 'Systems' }),
+      ).toBeInTheDocument()
+    })
+
+    test('Job should not be accessible', async () => {
+      render(
+        <MemoryProvider startLocation={['/jobs']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('heading', { name: 'Request Scheduler' }),
+        ).not.toBeInTheDocument(),
+      )
+      expect(
+        screen.getByRole('heading', { name: 'Systems' }),
+      ).toBeInTheDocument()
+    })
+
+    test('System Admin should not be accessible', async () => {
+      render(
+        <MemoryProvider startLocation={['/admin/systems']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('heading', { name: 'Systems Management' }),
+        ).not.toBeInTheDocument(),
+      )
+      expect(
+        screen.getByRole('heading', { name: 'Systems' }),
+      ).toBeInTheDocument()
+    })
+
+    test('Garden Admin should not be accessible', async () => {
+      render(
+        <MemoryProvider startLocation={['/admin/gardens']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('heading', { name: 'Gardens Management' }),
+        ).not.toBeInTheDocument(),
+      )
+      expect(
+        screen.getByRole('heading', { name: 'Systems' }),
+      ).toBeInTheDocument()
+    })
+
+    test('Command Blocklist should not be accessible', async () => {
+      jest
+        .spyOn(Router, 'useParams')
+        .mockReturnValue({ systemName: TSystem.name })
+      render(
+        <MemoryProvider startLocation={['/admin/commandblocklist']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('heading', {
+            name: 'Command Publishing Blocklist',
+          }),
+        ).not.toBeInTheDocument(),
+      )
       expect(
         screen.getByRole('heading', { name: 'Systems' }),
       ).toBeInTheDocument()
     })
   })
 
-  test('Requests should be accessible', async () => {
-    render(
-      <MemoryProvider startLocation={['/requests']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() => {
-      expect(
-        screen.getByRole('heading', { name: 'Requests' }),
-      ).toBeInTheDocument()
+  describe('auth enabled, has access', () => {
+    beforeAll(() => {
+      mockAxios.onGet('/config').reply(200, TServerAuthConfig)
+      mockAxios.onGet(regexUsers).reply(200, TAdmin)
     })
-  })
 
-  test('Users should not be accessible', async () => {
-    render(
-      <MemoryProvider startLocation={['/admin/users']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() =>
-      expect(
-        screen.queryByRole('heading', { name: 'User Management' }),
-      ).not.toBeInTheDocument(),
-    )
-    await waitFor(() => {
-      expect(
-        screen.getByRole('heading', { name: 'Systems' }),
-      ).toBeInTheDocument()
+    afterAll(() => {
+      mockAxios.onGet('/config').reply(200, TServerConfig)
     })
-  })
 
-  test('Job should be accessible', async () => {
-    render(
-      <MemoryProvider startLocation={['/jobs']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() => {
-      expect(
-        screen.getByRole('heading', { name: 'Request Scheduler' }),
-      ).toBeInTheDocument()
+    test('Systems', async () => {
+      render(
+        <MemoryProvider startLocation={['/systems']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      // For some reason still logged in from previous suite
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { name: 'Systems' }),
+        ).toBeInTheDocument()
+      })
     })
-  })
 
-  test('System Admin should be accessible', async () => {
-    render(
-      <MemoryProvider startLocation={['/admin/systems']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() => {
-      expect(
-        screen.getByRole('heading', { name: 'Systems Management' }),
-      ).toBeInTheDocument()
-    })
-  })
-
-  test('Garden Admin should be accessible', async () => {
-    render(
-      <MemoryProvider startLocation={['/admin/gardens']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() => {
-      expect(
-        screen.getByRole('heading', { name: 'Gardens Management' }),
-      ).toBeInTheDocument()
-    })
-  })
-
-  test('Command Blocklist should be accessible', async () => {
-    jest
-      .spyOn(Router, 'useParams')
-      .mockReturnValue({ systemName: TSystem.name })
-    render(
-      <MemoryProvider startLocation={['/admin/commandblocklist']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() => {
-      expect(
-        screen.getByRole('heading', {
-          name: 'Command Publishing Blocklist',
-        }),
-      ).toBeInTheDocument()
-    })
-  })
-
-  test('Login should not be accessible', async () => {
-    jest
-      .spyOn(Router, 'useParams')
-      .mockReturnValue({ systemName: TSystem.name })
-    render(
-      <MemoryProvider startLocation={['/login']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() => {
-      expect(
-        screen.getByRole('heading', { name: 'Systems' }),
-      ).toBeInTheDocument()
-    })
-  })
-})
-
-describe('Routes with auth enabled, no access', () => {
-  beforeAll(() => {
-    mockAxios.onGet('/config').reply(200, TServerAuthConfig)
-    mockAxios.onGet(regexUsers).reply(200, TUser)
-  })
-
-  afterAll(() => {
-    mockAxios.onGet('/config').reply(200, TServerConfig)
-  })
-
-  test('Systems should be accessible', async () => {
-    render(
-      <MemoryProvider startLocation={['/systems']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() => {
-      expect(screen.getByLabelText('Password *')).toBeInTheDocument()
-    })
-    // For some reason have to do this only once
-    loginFN()
-    await waitFor(() => {
-      expect(
-        screen.getByRole('heading', { name: 'Systems' }),
-      ).toBeInTheDocument()
-    })
-  })
-
-  test('Requests should be accessible', async () => {
-    render(
-      <MemoryProvider startLocation={['/requests']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() => {
-      expect(
-        screen.getByRole('heading', { name: 'Requests' }),
-      ).toBeInTheDocument()
-    })
-  })
-
-  test('Users should not be accessible', async () => {
-    render(
-      <MemoryProvider startLocation={['/admin/users']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() =>
-      expect(
-        screen.queryByRole('heading', { name: 'User Management' }),
-      ).not.toBeInTheDocument(),
-    )
-    expect(screen.getByRole('heading', { name: 'Systems' })).toBeInTheDocument()
-  })
-
-  test('Job should not be accessible', async () => {
-    render(
-      <MemoryProvider startLocation={['/jobs']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() =>
-      expect(
-        screen.queryByRole('heading', { name: 'Request Scheduler' }),
-      ).not.toBeInTheDocument(),
-    )
-    expect(screen.getByRole('heading', { name: 'Systems' })).toBeInTheDocument()
-  })
-
-  test('System Admin should not be accessible', async () => {
-    render(
-      <MemoryProvider startLocation={['/admin/systems']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() =>
-      expect(
-        screen.queryByRole('heading', { name: 'Systems Management' }),
-      ).not.toBeInTheDocument(),
-    )
-    expect(screen.getByRole('heading', { name: 'Systems' })).toBeInTheDocument()
-  })
-
-  test('Garden Admin should not be accessible', async () => {
-    render(
-      <MemoryProvider startLocation={['/admin/gardens']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() =>
-      expect(
-        screen.queryByRole('heading', { name: 'Gardens Management' }),
-      ).not.toBeInTheDocument(),
-    )
-    expect(screen.getByRole('heading', { name: 'Systems' })).toBeInTheDocument()
-  })
-
-  test('Command Blocklist should not be accessible', async () => {
-    jest
-      .spyOn(Router, 'useParams')
-      .mockReturnValue({ systemName: TSystem.name })
-    render(
-      <MemoryProvider startLocation={['/admin/commandblocklist']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() =>
-      expect(
-        screen.queryByRole('heading', {
-          name: 'Command Publishing Blocklist',
-        }),
-      ).not.toBeInTheDocument(),
-    )
-    expect(screen.getByRole('heading', { name: 'Systems' })).toBeInTheDocument()
-  })
-})
-
-describe('Routes with auth enabled, has access', () => {
-  beforeAll(() => {
-    mockAxios.onGet('/config').reply(200, TServerAuthConfig)
-    mockAxios.onGet(regexUsers).reply(200, TAdmin)
-  })
-
-  afterAll(() => {
-    mockAxios.onGet('/config').reply(200, TServerConfig)
-  })
-
-  test('Systems', async () => {
-    render(
-      <MemoryProvider startLocation={['/systems']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    // For some reason still logged in from previous suite
-    await waitFor(() => {
-      expect(
-        screen.getByRole('heading', { name: 'Systems' }),
-      ).toBeInTheDocument()
-    })
-  })
-
-  test('Requests', async () => {
-    render(
-      <MemoryProvider startLocation={['/requests']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() => {
-      expect(
-        screen.getByRole('heading', { name: 'Requests' }),
-      ).toBeInTheDocument()
-    })
-    expect(
-      screen.queryByRole('heading', { name: 'Systems' }),
-    ).not.toBeInTheDocument()
-  })
-
-  test('Users', async () => {
-    render(
-      <MemoryProvider startLocation={['/admin/users']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() => {
-      expect(
-        screen.getByRole('heading', { name: 'User Management' }),
-      ).toBeInTheDocument()
-    })
-    expect(
-      screen.queryByRole('heading', { name: 'Systems' }),
-    ).not.toBeInTheDocument()
-  })
-
-  test('Job', async () => {
-    render(
-      <MemoryProvider startLocation={['/jobs']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() =>
-      expect(
-        screen.queryByRole('heading', { name: 'Systems' }),
-      ).not.toBeInTheDocument(),
-    )
-    expect(
-      screen.getByRole('heading', { name: 'Request Scheduler' }),
-    ).toBeInTheDocument()
-  })
-
-  test('System Admin', async () => {
-    render(
-      <MemoryProvider startLocation={['/admin/systems']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() =>
-      expect(
-        screen.queryByRole('heading', { name: 'Systems' }),
-      ).not.toBeInTheDocument(),
-    )
-    expect(
-      screen.getByRole('heading', { name: 'Systems Management' }),
-    ).toBeInTheDocument()
-  })
-
-  test('Garden Admin', async () => {
-    render(
-      <MemoryProvider startLocation={['/admin/gardens']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() =>
-      expect(
-        screen.queryByRole('heading', { name: 'Systems' }),
-      ).not.toBeInTheDocument(),
-    )
-    expect(
-      screen.getByRole('heading', { name: 'Gardens Management' }),
-    ).toBeInTheDocument()
-  })
-
-  test('Command Blocklist', async () => {
-    render(
-      <MemoryProvider startLocation={['/admin/commandblocklist']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() =>
-      expect(
-        screen.queryByRole('heading', { name: 'Systems' }),
-      ).not.toBeInTheDocument(),
-    )
-    expect(
-      screen.getByRole('heading', { name: 'Command Publishing Blocklist' }),
-    ).toBeInTheDocument()
-  })
-
-  test('Login should be accessible', async () => {
-    jest
-      .spyOn(Router, 'useParams')
-      .mockReturnValue({ systemName: TSystem.name })
-    render(
-      <MemoryProvider startLocation={['/login']}>
-        <Routes />
-      </MemoryProvider>,
-    )
-    await waitFor(() => {
+    test('Requests', async () => {
+      render(
+        <MemoryProvider startLocation={['/requests']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { name: 'Requests' }),
+        ).toBeInTheDocument()
+      })
       expect(
         screen.queryByRole('heading', { name: 'Systems' }),
       ).not.toBeInTheDocument()
     })
-    expect(
-      screen.getByRole('textbox', { name: 'Username' }),
-    ).toBeInTheDocument()
+
+    test('Users', async () => {
+      render(
+        <MemoryProvider startLocation={['/admin/users']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { name: 'User Management' }),
+        ).toBeInTheDocument()
+      })
+      expect(
+        screen.queryByRole('heading', { name: 'Systems' }),
+      ).not.toBeInTheDocument()
+    })
+
+    test('Job', async () => {
+      render(
+        <MemoryProvider startLocation={['/jobs']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('heading', { name: 'Systems' }),
+        ).not.toBeInTheDocument(),
+      )
+      expect(
+        screen.getByRole('heading', { name: 'Request Scheduler' }),
+      ).toBeInTheDocument()
+    })
+
+    test('System Admin', async () => {
+      render(
+        <MemoryProvider startLocation={['/admin/systems']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('heading', { name: 'Systems' }),
+        ).not.toBeInTheDocument(),
+      )
+      expect(
+        screen.getByRole('heading', { name: 'Systems Management' }),
+      ).toBeInTheDocument()
+    })
+
+    test('Garden Admin', async () => {
+      render(
+        <MemoryProvider startLocation={['/admin/gardens']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('heading', { name: 'Systems' }),
+        ).not.toBeInTheDocument(),
+      )
+      expect(
+        screen.getByRole('heading', { name: 'Gardens Management' }),
+      ).toBeInTheDocument()
+    })
+
+    test('Command Blocklist', async () => {
+      render(
+        <MemoryProvider startLocation={['/admin/commandblocklist']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('heading', { name: 'Systems' }),
+        ).not.toBeInTheDocument(),
+      )
+      expect(
+        screen.getByRole('heading', { name: 'Command Publishing Blocklist' }),
+      ).toBeInTheDocument()
+    })
+
+    test('Login should be accessible', async () => {
+      jest
+        .spyOn(Router, 'useParams')
+        .mockReturnValue({ systemName: TSystem.name })
+      render(
+        <MemoryProvider startLocation={['/login']}>
+          <Routes />
+        </MemoryProvider>,
+      )
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('heading', { name: 'Systems' }),
+        ).not.toBeInTheDocument()
+      })
+      expect(
+        screen.getByRole('textbox', { name: 'Username' }),
+      ).toBeInTheDocument()
+    })
   })
 })

--- a/src/components/Routes/Routes.test.tsx
+++ b/src/components/Routes/Routes.test.tsx
@@ -31,11 +31,14 @@ describe('Routes', () => {
         <Routes />
       </SuspendedProviders>,
     )
-    await waitFor(() => {
-      expect(
-        screen.getByRole('heading', { name: 'Systems' }),
-      ).toBeInTheDocument()
-    })
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole('heading', { name: 'Systems' }),
+        ).toBeInTheDocument()
+      },
+      { timeout: 2500 },
+    )
     expect(
       screen.getByRole('heading', { name: 'Systems' }).textContent,
     ).toEqual('Systems')

--- a/src/components/UI/NavigationBar/MenuList/AdminMenu.test.tsx
+++ b/src/components/UI/NavigationBar/MenuList/AdminMenu.test.tsx
@@ -1,13 +1,28 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { NavigationBarContextProvider } from 'components/UI/NavigationBar/NavigationBarContext'
-import { mockAxios, regexUsers } from 'test/axios-mock'
-import { TServerAuthConfig } from 'test/test-values'
-import { AllProviders, LoggedInProviders } from 'test/testMocks'
-import { TUser } from 'test/user-test-values'
+import { ServerConfigContainer } from 'containers/ConfigContainer'
+import { PermissionsContainer } from 'containers/PermissionsContainer'
+import { TServerConfig } from 'test/test-values'
+import { AllProviders } from 'test/testMocks'
 
 import { AdminMenu } from './AdminMenu'
 
 describe('Admin Menu', () => {
+  beforeEach(() => {
+    jest.spyOn(PermissionsContainer, 'useContainer').mockReturnValue({
+      hasGardenPermission: jest.fn(),
+      hasPermission: () => true,
+      hasSystemPermission: jest.fn(),
+      hasJobPermission: jest.fn(),
+      isPermissionsSet: jest.fn(),
+    })
+    jest.spyOn(ServerConfigContainer, 'useContainer').mockReturnValue({
+      config: TServerConfig,
+      authEnabled: false,
+      debugEnabled: false,
+    })
+  })
+
   test('makes menu', async () => {
     render(
       <AllProviders>
@@ -69,26 +84,32 @@ describe('Admin Menu', () => {
 
   describe('menu items only for specific user access', () => {
     test('lists users', async () => {
-      const userObj = Object.assign({}, TUser, {
-        permissions: {
-          global_permissions: ['user:update'],
-          domain_permissions: {},
+      jest.spyOn(PermissionsContainer, 'useContainer').mockReturnValue({
+        hasGardenPermission: jest.fn(),
+        hasPermission: (p: string) => {
+          return (
+            ['user:update'].includes(p) ||
+            Object.prototype.hasOwnProperty.call(['user:update'], p)
+          )
         },
+        hasSystemPermission: jest.fn(),
+        hasJobPermission: jest.fn(),
+        isPermissionsSet: jest.fn(),
       })
-      // change return to enable auth
-      mockAxios.onGet('/config').reply(200, TServerAuthConfig)
-      mockAxios.onGet(regexUsers).reply(200, userObj)
+      jest.spyOn(ServerConfigContainer, 'useContainer').mockReturnValue({
+        config: TServerConfig,
+        authEnabled: true,
+        debugEnabled: false,
+      })
       render(
-        <LoggedInProviders>
+        <AllProviders>
           <NavigationBarContextProvider
-            toggleDrawer={(open: boolean) => () => {
-              // noop
-            }}
+            toggleDrawer={jest.fn()}
             drawerIsOpen={true}
           >
             <AdminMenu />
           </NavigationBarContextProvider>
-        </LoggedInProviders>,
+        </AllProviders>,
       )
       fireEvent.click(screen.getByTestId('ExpandMoreIcon'))
       await waitFor(() => {
@@ -102,26 +123,27 @@ describe('Admin Menu', () => {
     })
 
     test('lists garden and blocklist', async () => {
-      const userObj = Object.assign({}, TUser, {
-        permissions: {
-          global_permissions: ['garden:update'],
-          domain_permissions: {},
+      jest.spyOn(PermissionsContainer, 'useContainer').mockReturnValue({
+        hasGardenPermission: jest.fn(),
+        hasPermission: (p: string) => {
+          return (
+            ['garden:update'].includes(p) ||
+            Object.prototype.hasOwnProperty.call(['garden:update'], p)
+          )
         },
+        hasSystemPermission: jest.fn(),
+        hasJobPermission: jest.fn(),
+        isPermissionsSet: jest.fn(),
       })
-      // change return to enable auth
-      mockAxios.onGet('/config').reply(200, TServerAuthConfig)
-      mockAxios.onGet(regexUsers).reply(200, userObj)
       render(
-        <LoggedInProviders>
+        <AllProviders>
           <NavigationBarContextProvider
-            toggleDrawer={(open: boolean) => () => {
-              // noop
-            }}
+            toggleDrawer={jest.fn()}
             drawerIsOpen={true}
           >
             <AdminMenu />
           </NavigationBarContextProvider>
-        </LoggedInProviders>,
+        </AllProviders>,
       )
       fireEvent.click(screen.getByTestId('ExpandMoreIcon'))
       await waitFor(() => {
@@ -137,26 +159,27 @@ describe('Admin Menu', () => {
     })
 
     test('lists system', async () => {
-      const userObj = Object.assign({}, TUser, {
-        permissions: {
-          global_permissions: ['system:update'],
-          domain_permissions: {},
+      jest.spyOn(PermissionsContainer, 'useContainer').mockReturnValue({
+        hasGardenPermission: jest.fn(),
+        hasPermission: (p: string) => {
+          return (
+            ['system:update'].includes(p) ||
+            Object.prototype.hasOwnProperty.call(['system:update'], p)
+          )
         },
+        hasSystemPermission: jest.fn(),
+        hasJobPermission: jest.fn(),
+        isPermissionsSet: jest.fn(),
       })
-      // change return to enable auth
-      mockAxios.onGet('/config').reply(200, TServerAuthConfig)
-      mockAxios.onGet(regexUsers).reply(200, userObj)
       render(
-        <LoggedInProviders>
+        <AllProviders>
           <NavigationBarContextProvider
-            toggleDrawer={(open: boolean) => () => {
-              // noop
-            }}
+            toggleDrawer={jest.fn()}
             drawerIsOpen={true}
           >
             <AdminMenu />
           </NavigationBarContextProvider>
-        </LoggedInProviders>,
+        </AllProviders>,
       )
       fireEvent.click(screen.getByTestId('ExpandMoreIcon'))
       await waitFor(() => {

--- a/src/components/UI/NavigationBar/MenuList/LogoutButton.test.tsx
+++ b/src/components/UI/NavigationBar/MenuList/LogoutButton.test.tsx
@@ -1,37 +1,29 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { NavigationBarContextProvider } from 'components/UI/NavigationBar/NavigationBarContext'
-import { mockAxios } from 'test/axios-mock'
-import { TServerAuthConfig } from 'test/test-values'
-import { LoggedInProviders } from 'test/testMocks'
+import { AuthContainer } from 'containers/AuthContainer'
+import { AllProviders } from 'test/testMocks'
 
-import { MenuList } from './MenuList'
+import { LogoutButton } from './LogoutButton'
 
 describe('LogoutButton', () => {
   test('logs user out when clicked', async () => {
-    mockAxios.onGet('/config').reply(200, TServerAuthConfig)
-
+    const logOutTrigger = jest.fn()
+    jest.spyOn(AuthContainer, 'useContainer').mockReturnValue({
+      user: 'admin',
+      login: jest.fn(),
+      logout: logOutTrigger,
+      refreshToken: jest.fn(),
+      isAuthenticated: jest.fn(),
+      tokenExpiration: new Date(),
+    })
     render(
-      <LoggedInProviders>
-        <NavigationBarContextProvider
-          toggleDrawer={(open: boolean) => () => {
-            // noop
-          }}
-          drawerIsOpen={true}
-        >
-          <MenuList />
-        </NavigationBarContextProvider>
-      </LoggedInProviders>,
+      <AllProviders>
+        <LogoutButton />
+      </AllProviders>,
     )
-
     await waitFor(() => {
       expect(screen.getByText('Logout')).toBeInTheDocument()
     })
-
-    const logOutButton = screen.getByText('Logout')
-    fireEvent.click(logOutButton)
-
-    await waitFor(() => {
-      expect(screen.queryByText('Logout')).not.toBeInTheDocument()
-    })
+    fireEvent.click(screen.getByText('Logout'))
+    expect(logOutTrigger).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/components/UI/NavigationBar/MenuList/MenuList.test.tsx
+++ b/src/components/UI/NavigationBar/MenuList/MenuList.test.tsx
@@ -1,127 +1,149 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { NavigationBarContextProvider } from 'components/UI/NavigationBar/NavigationBarContext'
-import { mockAxios, regexUsers } from 'test/axios-mock'
-import { TServerAuthConfig } from 'test/test-values'
-import { AllProviders, LoggedInProviders } from 'test/testMocks'
-import { TAdmin, TUser } from 'test/user-test-values'
+import { AuthContainer } from 'containers/AuthContainer'
+import { PermissionsContainer } from 'containers/PermissionsContainer'
+import { AllProviders } from 'test/testMocks'
+import { TUser } from 'test/user-test-values'
 
 import { MenuList } from './MenuList'
 
 describe('Menu List', () => {
-  test('should hide Logout button when not logged in', async () => {
-    render(
-      <AllProviders>
-        <NavigationBarContextProvider
-          toggleDrawer={(open: boolean) => () => {
-            // noop
-          }}
-          drawerIsOpen={true}
-        >
-          <MenuList />
-        </NavigationBarContextProvider>
-      </AllProviders>,
-    )
-    await waitFor(() => {
-      expect(screen.queryByText('Logout')).not.toBeInTheDocument()
+  beforeEach(() => {
+    jest.spyOn(AuthContainer, 'useContainer').mockReturnValue({
+      user: TUser.username,
+      login: jest.fn(),
+      logout: jest.fn(),
+      refreshToken: jest.fn(),
+      isAuthenticated: jest.fn(),
+      tokenExpiration: new Date(),
     })
   })
 
-  test('should show logout button when logged in', async () => {
-    mockAxios.onGet('/config').reply(200, TServerAuthConfig)
-    render(
-      <LoggedInProviders>
-        <NavigationBarContextProvider
-          toggleDrawer={(open: boolean) => () => {
-            // noop
-          }}
-          drawerIsOpen={true}
-        >
-          <MenuList />
-        </NavigationBarContextProvider>
-      </LoggedInProviders>,
-    )
-    await waitFor(() => {
-      expect(screen.getByText('Logout')).toBeInTheDocument()
+  describe('with permission', () => {
+    beforeEach(() => {
+      jest.spyOn(PermissionsContainer, 'useContainer').mockReturnValue({
+        hasGardenPermission: jest.fn(),
+        hasPermission: () => true,
+        hasSystemPermission: jest.fn(),
+        hasJobPermission: jest.fn(),
+        isPermissionsSet: jest.fn(),
+      })
+    })
+
+    test('should show logout button when logged in', async () => {
+      render(
+        <AllProviders>
+          <NavigationBarContextProvider
+            toggleDrawer={jest.fn()}
+            drawerIsOpen={true}
+          >
+            <MenuList />
+          </NavigationBarContextProvider>
+        </AllProviders>,
+      )
+      await waitFor(() => {
+        expect(screen.getByText('Logout')).toBeInTheDocument()
+      })
+    })
+
+    test('should show admin menu', async () => {
+      render(
+        <AllProviders>
+          <NavigationBarContextProvider
+            toggleDrawer={jest.fn()}
+            drawerIsOpen={true}
+          >
+            <MenuList />
+          </NavigationBarContextProvider>
+        </AllProviders>,
+      )
+      await waitFor(() => {
+        expect(screen.getByText('Admin')).toBeInTheDocument()
+      })
+    })
+
+    test('should show Scheduler option', async () => {
+      render(
+        <AllProviders>
+          <NavigationBarContextProvider
+            toggleDrawer={jest.fn()}
+            drawerIsOpen={true}
+          >
+            <MenuList />
+          </NavigationBarContextProvider>
+        </AllProviders>,
+      )
+      await waitFor(() => {
+        expect(screen.getByText('Scheduler')).toBeInTheDocument()
+      })
     })
   })
 
-  test('should show admin menu when permission', async () => {
-    mockAxios.onGet('/config').reply(200, TServerAuthConfig)
-    mockAxios.onGet(regexUsers).reply(200, TAdmin)
-    render(
-      <LoggedInProviders>
-        <NavigationBarContextProvider
-          toggleDrawer={(open: boolean) => () => {
-            // noop
-          }}
-          drawerIsOpen={true}
-        >
-          <MenuList />
-        </NavigationBarContextProvider>
-      </LoggedInProviders>,
-    )
-    await waitFor(() => {
-      expect(screen.getByText('Admin')).toBeInTheDocument()
+  describe('without permission', () => {
+    beforeEach(() => {
+      jest.spyOn(PermissionsContainer, 'useContainer').mockReturnValue({
+        hasGardenPermission: jest.fn(),
+        hasPermission: () => false,
+        hasSystemPermission: jest.fn(),
+        hasJobPermission: jest.fn(),
+        isPermissionsSet: jest.fn(),
+      })
     })
-  })
 
-  test('should not show admin menu when no permission', async () => {
-    mockAxios.onGet('/config').reply(200, TServerAuthConfig)
-    mockAxios.onGet(regexUsers).reply(200, TUser)
-    render(
-      <LoggedInProviders>
-        <NavigationBarContextProvider
-          toggleDrawer={(open: boolean) => () => {
-            // noop
-          }}
-          drawerIsOpen={true}
-        >
-          <MenuList />
-        </NavigationBarContextProvider>
-      </LoggedInProviders>,
-    )
-    await waitFor(() => {
-      expect(screen.queryByText('Admin')).not.toBeInTheDocument()
+    test('should hide Logout button when not logged in', async () => {
+      jest.spyOn(AuthContainer, 'useContainer').mockReturnValue({
+        user: null,
+        login: jest.fn(),
+        logout: jest.fn(),
+        refreshToken: jest.fn(),
+        isAuthenticated: jest.fn(),
+        tokenExpiration: new Date(),
+      })
+      render(
+        <AllProviders>
+          <NavigationBarContextProvider
+            toggleDrawer={jest.fn()}
+            drawerIsOpen={true}
+          >
+            <MenuList />
+          </NavigationBarContextProvider>
+        </AllProviders>,
+      )
+      await waitFor(() => {
+        expect(screen.queryByText('Logout')).not.toBeInTheDocument()
+      })
     })
-  })
 
-  test('should not show scheduler when no permission', async () => {
-    mockAxios.onGet('/config').reply(200, TServerAuthConfig)
-    mockAxios.onGet(regexUsers).reply(200, TUser)
-    render(
-      <LoggedInProviders>
-        <NavigationBarContextProvider
-          toggleDrawer={(open: boolean) => () => {
-            // noop
-          }}
-          drawerIsOpen={true}
-        >
-          <MenuList />
-        </NavigationBarContextProvider>
-      </LoggedInProviders>,
-    )
-    await waitFor(() => {
-      expect(screen.queryByText('Scheduler')).not.toBeInTheDocument()
+    test('should not show admin menu when no permission', async () => {
+      render(
+        <AllProviders>
+          <NavigationBarContextProvider
+            toggleDrawer={jest.fn()}
+            drawerIsOpen={true}
+          >
+            <MenuList />
+          </NavigationBarContextProvider>
+        </AllProviders>,
+      )
+      await waitFor(() => {
+        expect(screen.queryByText('Admin')).not.toBeInTheDocument()
+      })
     })
-  })
 
-  test('should show Scheduler option when permission', async () => {
-    mockAxios.onGet('/config').reply(200, TServerAuthConfig)
-    mockAxios.onGet(regexUsers).reply(200, TAdmin)
-    render(
-      <LoggedInProviders>
-        <NavigationBarContextProvider
-          toggleDrawer={(open: boolean) => () => {
-            // noop
-          }}
-          drawerIsOpen={true}
-        >
-          <MenuList />
-        </NavigationBarContextProvider>
-      </LoggedInProviders>,
-    )
-    await waitFor(() => {
-      expect(screen.getByText('Scheduler')).toBeInTheDocument()
+    test('should not show scheduler when no permission', async () => {
+      render(
+        <AllProviders>
+          <NavigationBarContextProvider
+            toggleDrawer={jest.fn()}
+            drawerIsOpen={true}
+          >
+            <MenuList />
+          </NavigationBarContextProvider>
+        </AllProviders>,
+      )
+      await waitFor(() => {
+        expect(screen.queryByText('Scheduler')).not.toBeInTheDocument()
+      })
     })
   })
 })

--- a/src/pages/CommandIndex/CommandIndex.test.tsx
+++ b/src/pages/CommandIndex/CommandIndex.test.tsx
@@ -5,7 +5,7 @@ import Router from 'react-router-dom'
 import { mockAxios } from 'test/axios-mock'
 import { TSystem } from 'test/system-test-values'
 import { TServerConfig } from 'test/test-values'
-import { AllProviders, LoggedInProviders } from 'test/testMocks'
+import { AllProviders, MemoryProvider } from 'test/testMocks'
 
 import { CommandIndex } from './CommandIndex'
 
@@ -247,9 +247,9 @@ describe('CommandIndex', () => {
     })
     mockAxios.onGet('/api/v1/systems').reply(200, [TSystem])
     render(
-      <LoggedInProviders>
+      <MemoryProvider startLocation={['/systems/test/testCommand/1.0.0']}>
         <CommandIndex />
-      </LoggedInProviders>,
+      </MemoryProvider>,
     )
     await waitFor(() => {
       expect(screen.getByText('Execute')).toBeInTheDocument()
@@ -275,9 +275,9 @@ describe('CommandIndex', () => {
       version: TSystem.version,
     })
     render(
-      <LoggedInProviders>
+      <MemoryProvider startLocation={['/systems/test/testCommand/1.0.0']}>
         <CommandIndex />
-      </LoggedInProviders>,
+      </MemoryProvider>,
     )
     await waitFor(() => {
       expect(screen.queryByText('Execute')).not.toBeInTheDocument()

--- a/src/pages/CommandIndex/ExecuteButton.test.tsx
+++ b/src/pages/CommandIndex/ExecuteButton.test.tsx
@@ -1,20 +1,24 @@
 import { render, screen, waitFor } from '@testing-library/react'
-import { mockAxios, regexUsers } from 'test/axios-mock'
+import { PermissionsContainer } from 'containers/PermissionsContainer'
 import { TSystem } from 'test/system-test-values'
-import { TAugmentedCommand, TServerAuthConfig } from 'test/test-values'
-import { LoggedInProviders } from 'test/testMocks'
-import { TAdmin, TUser } from 'test/user-test-values'
+import { TAugmentedCommand } from 'test/test-values'
+import { AllProviders } from 'test/testMocks'
 
 import { ExecuteButton } from './ExecuteButton'
 
 describe('ExecuteButton', () => {
   test('execute button if permission', async () => {
-    mockAxios.onGet('/config').reply(200, TServerAuthConfig)
-    mockAxios.onGet(regexUsers).reply(200, TAdmin)
+    jest.spyOn(PermissionsContainer, 'useContainer').mockReturnValue({
+      hasGardenPermission: jest.fn(),
+      hasPermission: () => true,
+      hasSystemPermission: jest.fn(),
+      hasJobPermission: jest.fn(),
+      isPermissionsSet: jest.fn(),
+    })
     render(
-      <LoggedInProviders>
+      <AllProviders>
         <ExecuteButton system={TSystem} command={TAugmentedCommand} />
-      </LoggedInProviders>,
+      </AllProviders>,
     )
     await waitFor(() => {
       expect(screen.getByText('Execute')).toBeInTheDocument()
@@ -22,12 +26,17 @@ describe('ExecuteButton', () => {
   })
 
   test('disabled execute button if no permission', async () => {
-    mockAxios.onGet('/config').reply(200, TServerAuthConfig)
-    mockAxios.onGet(regexUsers).reply(200, TUser)
+    jest.spyOn(PermissionsContainer, 'useContainer').mockReturnValue({
+      hasGardenPermission: jest.fn(),
+      hasPermission: () => false,
+      hasSystemPermission: jest.fn(),
+      hasJobPermission: jest.fn(),
+      isPermissionsSet: jest.fn(),
+    })
     render(
-      <LoggedInProviders>
+      <AllProviders>
         <ExecuteButton system={TSystem} command={TAugmentedCommand} />
-      </LoggedInProviders>,
+      </AllProviders>,
     )
     // check button is disabled, but its aria-disabled
     await waitFor(() => {

--- a/src/pages/CommandView/CommandView.test.tsx
+++ b/src/pages/CommandView/CommandView.test.tsx
@@ -73,7 +73,6 @@ describe('CommandView', () => {
         screen.getByDisplayValue(TRequestCommandModel.comment.comment),
       ).toBeInTheDocument()
     })
-    console.log(TAugmentedCommand.parameters[0].key)
     // parameter value is inserted
     const paramString = TRequestCommandModel.parameters[
       TParameter.key

--- a/src/pages/JobIndex/JobIndex.test.tsx
+++ b/src/pages/JobIndex/JobIndex.test.tsx
@@ -1,8 +1,8 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { mockAxios, regexUsers } from 'test/axios-mock'
-import { TJob, TServerAuthConfig } from 'test/test-values'
-import { AllProviders, LoggedInProviders } from 'test/testMocks'
-import { TAdmin, TUser } from 'test/user-test-values'
+import { PermissionsContainer } from 'containers/PermissionsContainer'
+import { mockAxios } from 'test/axios-mock'
+import { TJob } from 'test/test-values'
+import { AllProviders } from 'test/testMocks'
 
 import { JobIndex } from './JobIndex'
 
@@ -46,6 +46,16 @@ function createFile(
 }
 
 describe('JobIndex', () => {
+  beforeEach(() => {
+    jest.spyOn(PermissionsContainer, 'useContainer').mockReturnValue({
+      hasGardenPermission: jest.fn(),
+      hasPermission: () => true,
+      hasSystemPermission: jest.fn(),
+      hasJobPermission: jest.fn(),
+      isPermissionsSet: jest.fn(),
+    })
+  })
+
   test('displays table with job data', async () => {
     render(
       <AllProviders>
@@ -98,12 +108,17 @@ describe('JobIndex', () => {
 
   describe('import', () => {
     test('no button if no permission', async () => {
-      mockAxios.onGet('/config').reply(200, TServerAuthConfig)
-      mockAxios.onGet(regexUsers).reply(200, TUser)
+      jest.spyOn(PermissionsContainer, 'useContainer').mockReturnValue({
+        hasGardenPermission: jest.fn(),
+        hasPermission: () => false,
+        hasSystemPermission: jest.fn(),
+        hasJobPermission: jest.fn(),
+        isPermissionsSet: jest.fn(),
+      })
       render(
-        <LoggedInProviders>
+        <AllProviders>
           <JobIndex />
-        </LoggedInProviders>,
+        </AllProviders>,
       )
       await waitFor(() => {
         expect(screen.queryByText('IMPORT')).not.toBeInTheDocument()
@@ -111,12 +126,10 @@ describe('JobIndex', () => {
     })
 
     test('button if permission', async () => {
-      mockAxios.onGet('/config').reply(200, TServerAuthConfig)
-      mockAxios.onGet(regexUsers).reply(200, TAdmin)
       render(
-        <LoggedInProviders>
+        <AllProviders>
           <JobIndex />
-        </LoggedInProviders>,
+        </AllProviders>,
       )
       await waitFor(() => {
         expect(screen.getByText('IMPORT')).toBeInTheDocument()
@@ -125,9 +138,9 @@ describe('JobIndex', () => {
 
     test('button opens dialog', async () => {
       render(
-        <LoggedInProviders>
+        <AllProviders>
           <JobIndex />
-        </LoggedInProviders>,
+        </AllProviders>,
       )
       fireEvent.click(screen.getByText('IMPORT'))
       await waitFor(() => {
@@ -140,9 +153,9 @@ describe('JobIndex', () => {
     test('cancel dialog', async () => {
       mockAxios.onGet('/api/v1/jobs').reply(200, [])
       render(
-        <LoggedInProviders>
+        <AllProviders>
           <JobIndex />
-        </LoggedInProviders>,
+        </AllProviders>,
       )
       fireEvent.click(screen.getByText('IMPORT'))
       await waitFor(() => {
@@ -163,9 +176,9 @@ describe('JobIndex', () => {
       const files = [createFile('file1', [JSON.stringify([TJob])])]
       const data = createDtWithFiles(files)
       render(
-        <LoggedInProviders>
+        <AllProviders>
           <JobIndex />
-        </LoggedInProviders>,
+        </AllProviders>,
       )
       fireEvent.click(screen.getByText('IMPORT'))
       await waitFor(() => {
@@ -194,9 +207,9 @@ describe('JobIndex', () => {
       const files = [createFile('file1', [], 'img/png')]
       const data = createDtWithFiles(files)
       render(
-        <LoggedInProviders>
+        <AllProviders>
           <JobIndex />
-        </LoggedInProviders>,
+        </AllProviders>,
       )
       fireEvent.click(screen.getByText('IMPORT'))
       await waitFor(() => {
@@ -218,12 +231,10 @@ describe('JobIndex', () => {
   })
 
   test('create button if permission', async () => {
-    mockAxios.onGet('/config').reply(200, TServerAuthConfig)
-    mockAxios.onGet(regexUsers).reply(200, TAdmin)
     render(
-      <LoggedInProviders>
+      <AllProviders>
         <JobIndex />
-      </LoggedInProviders>,
+      </AllProviders>,
     )
     await waitFor(() => {
       expect(screen.getByText('Create')).toBeInTheDocument()
@@ -231,12 +242,17 @@ describe('JobIndex', () => {
   })
 
   test('no create button if no permission', async () => {
-    mockAxios.onGet('/config').reply(200, TServerAuthConfig)
-    mockAxios.onGet(regexUsers).reply(200, TUser)
+    jest.spyOn(PermissionsContainer, 'useContainer').mockReturnValue({
+      hasGardenPermission: jest.fn(),
+      hasPermission: () => false,
+      hasSystemPermission: jest.fn(),
+      hasJobPermission: jest.fn(),
+      isPermissionsSet: jest.fn(),
+    })
     render(
-      <LoggedInProviders>
+      <AllProviders>
         <JobIndex />
-      </LoggedInProviders>,
+      </AllProviders>,
     )
     await waitFor(() => {
       expect(screen.queryByText('Create')).not.toBeInTheDocument()

--- a/src/pages/RequestsIndex/requestsIndexData.tsx
+++ b/src/pages/RequestsIndex/requestsIndexData.tsx
@@ -104,8 +104,8 @@ const useRequests = () => {
    * updated) and update our own state.
    */
   useEffect(() => {
-    if (response && !error) {
-      if (data) {
+    if (data && !error) {
+      if (response?.headers) {
         setRequests(formatBeergardenRequests(data))
 
         const {
@@ -122,8 +122,10 @@ const useRequests = () => {
           requested: searchApi.length,
           recordsFiltered: parseInt(recordsFiltered),
           recordsTotal: parseInt(recordsTotal),
-          draw: draw.length > 0 ? parseInt(draw) : undefined,
+          draw: draw?.length > 0 ? parseInt(draw) : undefined,
         })
+      } else {
+        setIsErrored(true)
       }
     } else if (error) {
       setIsErrored(!!error)

--- a/src/test/axios-mock.ts
+++ b/src/test/axios-mock.ts
@@ -20,6 +20,7 @@ const mockToken =
 
 const regexLogs = new RegExp(/(\/api\/v1\/instances\/)\w+(\/logs)/)
 export const regexUsers = new RegExp(/(\/api\/v1\/users\/)\w+/)
+const regexRequests = new RegExp(/\/api\/v1\/requests\?/)
 const regexQueues = new RegExp(/(\/api\/v1\/instances\/)(\w+[^bad])(\/queues)/)
 
 // Success GET
@@ -35,6 +36,13 @@ mock.onGet('/api/v1/users').reply(200, { users: [TUser] })
 mock.onGet(regexUsers).reply(200, TUser)
 mock.onGet('/api/v1/roles').reply(200, { roles: [TRole, TAdminRole] })
 mock.onGet('/api/v1/requests/1234').reply(200, mockData.TRequest)
+mock.onGet(regexRequests).reply(200, [mockData.TRequest], {
+  start: '0',
+  length: '5',
+  recordsfiltered: '4',
+  recordstotal: '5',
+  draw: '2',
+})
 mock.onGet('/api/v1/namespaces').reply(200, ['test'])
 mock.onGet('/api/v1/users/adminUser').reply((config: AxiosRequestConfig) => {
   // this can be updated to be dynamic by parsing config.url for name

--- a/src/test/axios-mock.ts
+++ b/src/test/axios-mock.ts
@@ -15,6 +15,9 @@ axios.defaults.baseURL = 'http://localhost:4000'
 
 const mock = new MockAdapter(axios)
 
+const mockToken =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlcm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMiwicGVybWlzc2lvbnMiOiJzb21lIiwidHlwZSI6ImFjY2VzcyJ9.4ooLLSdOD-221RbrVsueEglJY8JRPIebIAuQ8K2APVw'
+
 const regexLogs = new RegExp(/(\/api\/v1\/instances\/)\w+(\/logs)/)
 export const regexUsers = new RegExp(/(\/api\/v1\/users\/)\w+/)
 const regexQueues = new RegExp(/(\/api\/v1\/instances\/)(\w+[^bad])(\/queues)/)
@@ -50,7 +53,14 @@ mock
 
 // Success POST
 mock.onPost('/api/v1/requests').reply(200, { id: 'testRequest' })
-mock.onPost('/api/v1/token').reply(200, { access: 'admin', refresh: 'none' })
+mock.onPost('/api/v1/token').reply(200, {
+  access: mockToken,
+  refresh: mockToken,
+})
+mock.onPost('/api/v1/token/refresh').reply(200, {
+  access: mockToken,
+  refresh: mockToken,
+})
 mock.onPost('/api/v1/users').reply(200, { users: [TAdmin] })
 mock.onPost('/api/v1/gardens').reply(200, TGarden)
 mock.onPost('/api/v1/import/jobs').reply(200, { ids: [mockData.TJob.id] })

--- a/src/test/testMocks.tsx
+++ b/src/test/testMocks.tsx
@@ -1,3 +1,4 @@
+import { fireEvent, screen } from '@testing-library/react'
 import ErrorBoundary from 'components/ErrorBoundary'
 import { AuthContainer } from 'containers/AuthContainer'
 import { ServerConfigContainer } from 'containers/ConfigContainer'
@@ -14,6 +15,16 @@ export interface ProviderMocks {
   user?: string
   pw?: string
   logs?: DebugSettings
+}
+
+export const loginFN = () => {
+  fireEvent.change(screen.getByRole('textbox', { name: 'Username' }), {
+    target: { value: 'admin' },
+  })
+  fireEvent.change(screen.getByLabelText('Password *'), {
+    target: { value: 'password' },
+  })
+  fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
 }
 
 /**
@@ -67,41 +78,6 @@ export const MemoryProvider = ({ children, startLocation }: ProviderMocks) => {
 }
 
 /**
- * Wrapper that puts children inside all props needed to render app properly
- * using MemoryRouter so a current page location can be given and username/password
- * to login with
- * @param children Component(s) to render as children
- * @param startLocation String path for page URL when test runs
- * @returns
- */
-export const LoggedInMemory = ({
-  children,
-  startLocation,
-  user,
-  pw,
-}: ProviderMocks) => {
-  return (
-    <MemoryRouter initialEntries={startLocation}>
-      <ErrorBoundary>
-        <ServerConfigContainer.Provider>
-          <DebugContainer.Provider>
-            <SocketContainer.Provider>
-              <AuthContainer.Provider>
-                <PermissionsContainer.Provider>
-                  <LoginProvider user={user} pw={pw}>
-                    <Suspense fallback={<>LOADING...</>}>{children}</Suspense>
-                  </LoginProvider>
-                </PermissionsContainer.Provider>
-              </AuthContainer.Provider>
-            </SocketContainer.Provider>
-          </DebugContainer.Provider>
-        </ServerConfigContainer.Provider>
-      </ErrorBoundary>
-    </MemoryRouter>
-  )
-}
-
-/**
  * Wrapper that just has config provider
  * @param children Component(s) to render as children
  * @returns
@@ -136,47 +112,6 @@ export const SuspendedProviders = ({ children }: ProviderMocks) => {
       </ErrorBoundary>
     </HashRouter>
   )
-}
-
-/**
- * Wrapper that puts children inside all props needed to render app properly
- * AND logs in as admin user
- * @param children Component(s) to render as children
- * @returns
- */
-export const LoggedInProviders = ({ children }: ProviderMocks) => {
-  return (
-    <HashRouter>
-      <ErrorBoundary>
-        <ServerConfigContainer.Provider>
-          <DebugContainer.Provider>
-            <SocketContainer.Provider>
-              <AuthContainer.Provider>
-                <PermissionsContainer.Provider>
-                  <LoginProvider>{children}</LoginProvider>
-                </PermissionsContainer.Provider>
-              </AuthContainer.Provider>
-            </SocketContainer.Provider>
-          </DebugContainer.Provider>
-        </ServerConfigContainer.Provider>
-      </ErrorBoundary>
-    </HashRouter>
-  )
-}
-
-const LoginProvider = ({ children, user, pw }: ProviderMocks) => {
-  const { login } = AuthContainer.useContainer()
-  const userName = user || 'admin'
-  const password = pw || 'password'
-  login(userName, password)
-    .then(() => {
-      // do nothing its a test
-    })
-    .catch((E) => {
-      // swallowing Error { message: "Invalid token specified: Cannot read
-      // properties of undefined (reading 'replace')" }
-    })
-  return <>{children}</>
 }
 
 /**


### PR DESCRIPTION
Closes #363 

Fixes all the problems with the unit tests so none are skipped and all are passing

There are some error logs that occur during the tests. They should be the message `data.tsx:handleRefresh() - error from execute: Cancel { message: undefined }` which is "intentionally" logged by the UI on the requests page.