### PR TITLE
#401 Garden status scrolls rather than expanding

### DIFF
--- a/src/components/LabeledData.test.tsx
+++ b/src/components/LabeledData.test.tsx
@@ -49,7 +49,7 @@ describe('Labeled Data Component', () => {
       </HashRouter>,
     )
     expect(screen.getByRole('alert')).toBeInTheDocument()
-    expect(screen.getByRole('alert')).toHaveClass('MuiAlert-standardSuccess')
+    expect(screen.getByRole('alert')).toHaveClass('MuiAlert-filledSuccess')
     expect(screen.queryByTestId('Test LabelLink')).not.toBeInTheDocument()
   })
 })

--- a/src/components/LabeledData.tsx
+++ b/src/components/LabeledData.tsx
@@ -15,7 +15,6 @@ const alertStyle = {
   '& .MuiAlert-message': {
     padding: '0px',
   },
-  width: '80%',
   py: 0.1,
 }
 
@@ -43,6 +42,7 @@ const LabeledData = ({ label, data, link, children, alert }: ILabelData) => {
         <Alert
           sx={alertStyle}
           icon={false}
+          variant="filled"
           severity={getSeverity(data as string)}
         >
           {data}

--- a/src/pages/GardenAdmin/GardenAdmin.tsx
+++ b/src/pages/GardenAdmin/GardenAdmin.tsx
@@ -57,9 +57,9 @@ const GardenAdmin = (): JSX.Element => {
       </Stack>
       <PageHeader title="Gardens Management" description="" />
       <Divider />
-      <Grid container spacing={3}>
+      <Grid container spacing={3} columns={3}>
         {gardens.map((garden: Garden) => (
-          <Grid key={garden['name']} item xs={4}>
+          <Grid key={garden['name']} item xs={1} sx={{minWidth: '375px'}}>
             <GardenAdminCard
               garden={garden}
               setRequestStatus={setRequestStatus}

--- a/src/pages/GardenAdmin/GardenAdminCard.tsx
+++ b/src/pages/GardenAdmin/GardenAdminCard.tsx
@@ -1,10 +1,10 @@
 import {
   AppBar,
-  Box,
   Button,
   Card,
   CardActions,
   CardContent,
+  Grid,
   Toolbar,
   Typography,
 } from '@mui/material'
@@ -58,7 +58,7 @@ const GardenAdminCard = ({
   }
 
   return (
-    <Card sx={{ minWidth: 275 }}>
+    <Card>
       <AppBar color="inherit" position="static">
         <Toolbar>
           <Typography variant="h3" color="inherit">
@@ -68,19 +68,20 @@ const GardenAdminCard = ({
         </Toolbar>
       </AppBar>
       <CardContent>
-        <Box
-          sx={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fill, 180px)',
-            justifyContent: 'center',
-            alignItems: 'center',
-            gap: 1,
-          }}
+        <Grid
+          container
+          spacing={4}
         >
-          <LabeledData label="Status" data={garden.status} alert />
-          <LabeledData label="Namespaces" data={garden.namespaces.length} />
-          <LabeledData label="Systems" data={garden.systems.length} />
-        </Box>
+          <Grid item >
+            <LabeledData label="Status" data={garden.status} alert />
+          </Grid>
+          <Grid item >
+            <LabeledData label="Namespaces" data={garden.namespaces.length} />
+          </Grid>
+          <Grid item >
+            <LabeledData label="Systems" data={garden.systems.length} />
+          </Grid>
+        </Grid>
       </CardContent>
       <CardActions>
         {hasGardenPermission('garden:update', garden) && (

--- a/src/pages/GardenAdminView/GardenAdminInfoCard.tsx
+++ b/src/pages/GardenAdminView/GardenAdminInfoCard.tsx
@@ -1,4 +1,4 @@
-import { Box, List, ListItem, Typography } from '@mui/material'
+import { Grid, List, ListItem, Typography } from '@mui/material'
 import { LabeledData } from 'components/LabeledData'
 import { Garden } from 'types/backend-types'
 
@@ -12,19 +12,23 @@ const GardenAdminInfoCard = ({ garden }: GardenInfoCardProps) => {
       <Typography variant="h3" color="inherit">
         Garden Info
       </Typography>
-      <Box
-        sx={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fill, 180px)',
-          justifyContent: 'center',
-          alignItems: 'center',
-          gap: 1,
-        }}
+      <Grid
+        container
+        columns={3}
+        rowSpacing={1}
+        columnSpacing={4}
+        pl={4}
       >
-        <LabeledData label="Name" data={garden.name} />
-        <LabeledData label="Status" data={garden.status} alert />
-        <LabeledData label="Connection Type" data={garden.connection_type} />
-        <Box sx={{ gridColumnStart: '1' }}>
+        <Grid item >
+          <LabeledData label="Name" data={garden.name} />
+        </Grid>
+        <Grid item >
+          <LabeledData label="Status" data={garden.status} alert />
+        </Grid>
+        <Grid item >
+          <LabeledData label="Connection Type" data={garden.connection_type} />
+        </Grid>
+        <Grid item xs={3} >
           <Typography sx={{ my: 2 }} fontWeight={'bold'} variant="overline">
             Known Namespaces:
           </Typography>
@@ -42,8 +46,8 @@ const GardenAdminInfoCard = ({ garden }: GardenInfoCardProps) => {
               </ListItem>
             ))}
           </List>
-        </Box>
-      </Box>
+        </Grid>
+      </Grid>
     </>
   )
 }


### PR DESCRIPTION
Closes #401 

Reworked how the garden admin pages does spacing around `LabeledData` so the alert no longer gets a horizontal scroll bar when the garden status is `NOT_CONFIGURED`.