### PR TITLE
Garden not editable alert moved 

### DIFF
--- a/src/pages/GardenAdminView/GardenAdminView.tsx
+++ b/src/pages/GardenAdminView/GardenAdminView.tsx
@@ -101,6 +101,13 @@ const GardenAdminView = () => {
       )}
       <PageHeader title="Garden View" description="" />
       <Divider />
+      {garden?.connection_type === 'LOCAL' &&
+        <Alert severity="info">
+          {
+            'Since this is the local Garden it is not possible to modify connection information'
+          }
+        </Alert>
+      }
       {garden ? (
         <>
           <GardenAdminInfoCard garden={garden} />
@@ -116,21 +123,14 @@ const GardenAdminView = () => {
             `Unable to display systems when status is ${garden.status}`
           )}
           <Divider />
-          {garden.connection_type === 'LOCAL' ? (
-            <Alert severity="info">
-              {
-                'Since this is the local Garden it is not possible to modify connection information'
-              }
-            </Alert>
-          ) : (
-            garden.connection_params && (
-              <GardenConnectionForm
-                garden={garden}
-                title="Update Connection Information"
-                formOnSubmit={formOnSubmit}
-              />
-            )
-          )}
+          {garden.connection_type !== 'LOCAL' &&
+            garden.connection_params &&
+            <GardenConnectionForm
+              garden={garden}
+              title="Update Connection Information"
+              formOnSubmit={formOnSubmit}
+            />
+          }
         </>
       ) : (
         <Backdrop open={true}>

--- a/src/pages/SystemIndex/systemIndexHelpers.tsx
+++ b/src/pages/SystemIndex/systemIndexHelpers.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react'
 import { Column } from 'react-table'
 import { System } from 'types/backend-types'
 
-type SystemIndexTableData = {
+export type SystemIndexTableData = {
   name: string
   description: string
   version: string
@@ -37,7 +37,7 @@ const useSystemIndexTableData = (systems: System[]): SystemIndexTableData[] => {
   return systems.map(systemMapper)
 }
 
-const useSystemIndexTableColumns = () => {
+const useSystemIndexTableColumns = (): Column<SystemIndexTableData>[] => {
   return useMemo<Column<SystemIndexTableData>[]>(
     () => [
       {

--- a/src/pages/SystemIndex/systemIndexHelpers.tsx
+++ b/src/pages/SystemIndex/systemIndexHelpers.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react'
 import { Column } from 'react-table'
 import { System } from 'types/backend-types'
 
-export type SystemIndexTableData = {
+type SystemIndexTableData = {
   name: string
   description: string
   version: string


### PR DESCRIPTION
Closes #399 

The garden not editable alert is moved to the top of the page to make it easier to see when viewing the local garden.