### PR TITLE
403 Final step of breadcrumb trail should not be blue

### DIFF
--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -37,7 +37,7 @@ const Breadcrumbs = ({ breadcrumbs: breadcrumbsArr }: MyBreadcrumbsProps) => {
               </RouterLink>
             </Tooltip>
           ))}
-        <Box component="span">{breadcrumbsArr[breadcrumbsArr.length - 1]}</Box>
+        <Box color="InfoText">{breadcrumbsArr[breadcrumbsArr.length - 1]}</Box>
       </MUIBreadcrumbs>
     )
   }


### PR DESCRIPTION
Closes #403 

Changed color of the trailing breadcrumb for the `CommandIndex` and the `CommandView`, so it is no longer blue.