### PR TITLE
402 Remove underlining for links

### DIFF
--- a/src/components/UI/Theme/Theme.ts
+++ b/src/components/UI/Theme/Theme.ts
@@ -28,6 +28,7 @@ function getTheme(themeName: SupportedColorScheme) {
         styleOverrides: {
           a: {
             color: d3,
+            textDecoration: 'none',
           },
           span: {
             fontSize: 18,
@@ -55,6 +56,7 @@ function getTheme(themeName: SupportedColorScheme) {
         styleOverrides: {
           a: {
             color: l3,
+            textDecoration: 'none',
           },
           span: {
             fontSize: 18,


### PR DESCRIPTION
Closes #402 

Set `textDecoration` to `'none'` in theme for `a` to remove underline from all links using tag `a`