### PR TITLE
425 Add dynamic command status indicator

### DIFF
--- a/src/components/FormComponents/FormTextField.tsx
+++ b/src/components/FormComponents/FormTextField.tsx
@@ -7,7 +7,7 @@ import { RegisterOptions, useFormContext } from 'react-hook-form'
 export type FormTextFieldProps = {
   registerKey: string
   registerOptions?: RegisterOptions
-  menuOptions?: (string | number)[]
+  menuOptions?: (string | number | null)[]
 } & TextFieldProps
 
 const defaultTextFieldProps: TextFieldProps = {
@@ -20,7 +20,7 @@ const defaultTextFieldProps: TextFieldProps = {
 }
 
 const FormTextField = ({ registerKey, registerOptions, menuOptions, ...textFieldProps }: FormTextFieldProps) => {
-  const { register, getFieldState, watch, } = useFormContext()
+  const { register, getFieldState, watch } = useFormContext()
   const [showPassword, setShowPassword] = useMountedState(false)
 
   const currentValue = watch(registerKey)
@@ -57,11 +57,15 @@ const FormTextField = ({ registerKey, registerOptions, menuOptions, ...textField
     <TextField
       select
       {...defaultTextFieldProps}
-      value={currentValue || ''}
       {...textFieldProps}
+      value={currentValue || ''}
       {...register(registerKey, registerOptions)}
     >
-      {menuOptions.map((value) => <MenuItem key={value} value={value}>{value}</MenuItem>)}
+      {menuOptions.map((value, index) => (
+        <MenuItem key={`${registerKey}-${value === null ? JSON.stringify(value) : value}-${index}`} value={value as string | number}>
+          {value === null ? JSON.stringify(value) : value}
+        </MenuItem>
+      ))}
     </TextField>
   ) : (
     <TextField

--- a/src/pages/CommandView/CommandJobForm.tsx
+++ b/src/pages/CommandView/CommandJobForm.tsx
@@ -53,6 +53,8 @@ const CommandJobForm = ({ system, command, isJob}: {system: StrippedSystem, comm
           else {
             if(parameter.default || parameter.default === false || parameter.type === 'Boolean') 
               defaultParamValues[parameter.key] = parameter.type === 'Boolean' ? parameter.default || false : parameter.default
+            else if(parameter.choices)
+              defaultParamValues[parameter.key] = ''
           }
       })
       return defaultParamValues


### PR DESCRIPTION
Closes #425

Added a `Tooltip` with an `Alert` or `CircularProgress` to the field label to indicate when a dependent field needs selected, if there was an error loading the choices or the choices are currently being loaded.

I found an issue with self referring dynamic commands where setting `registerOptions.setValueAs` caused a render loop and had to delete `registerOptions.setValueAs` so self referring dynamic commands would work again.