### PR TITLE
431 Regex error message

### DIFF
--- a/src/pages/CommandView/ParameterElements/ParamTextField.tsx
+++ b/src/pages/CommandView/ParameterElements/ParamTextField.tsx
@@ -81,7 +81,7 @@ const ParamTextField = ({ parameter, registerKey }: ParamTextFieldProps) => {
   }, [_setChoiceValues, getValues, parameter.choices?.display, parameter.nullable, registerKey, setValue])
 
   if(parameter.regex) {
-    registerOptions.pattern = new RegExp(parameter.regex)
+    registerOptions.pattern = {value: new RegExp(parameter.regex), message: `Value does not match pattern: ${parameter.regex}`}
   }
   
   if(parameter.nullable && !parameter.optional)


### PR DESCRIPTION
Closes #431 
Added error message when parameter field value does not match regex pattern. 

For testing the command `echo_required_message_regex` can be used to see that the error message appears. To get the error message to show, the form needs to be submitted with an error to trigger validation.
